### PR TITLE
chore: migrate to Spring Boot 3.2+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.8.RELEASE</version>
+		<version>3.2.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.github.codexrm</groupId>
@@ -47,6 +47,7 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
+
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
@@ -74,7 +75,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<version>1.18.32</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -103,6 +105,11 @@
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
     </dependencies>

--- a/src/main/java/io/github/codexrm/server/controller/AuthController.java
+++ b/src/main/java/io/github/codexrm/server/controller/AuthController.java
@@ -19,7 +19,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/io/github/codexrm/server/model/ArticleReference.java
+++ b/src/main/java/io/github/codexrm/server/model/ArticleReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "articlereference")

--- a/src/main/java/io/github/codexrm/server/model/BookLetReference.java
+++ b/src/main/java/io/github/codexrm/server/model/BookLetReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "bookletreference")

--- a/src/main/java/io/github/codexrm/server/model/BookReference.java
+++ b/src/main/java/io/github/codexrm/server/model/BookReference.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "bookreference")

--- a/src/main/java/io/github/codexrm/server/model/BookSectionReference.java
+++ b/src/main/java/io/github/codexrm/server/model/BookSectionReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "booksectionreference")

--- a/src/main/java/io/github/codexrm/server/model/ConferencePaperReference.java
+++ b/src/main/java/io/github/codexrm/server/model/ConferencePaperReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "conferencepaperreference")

--- a/src/main/java/io/github/codexrm/server/model/ConferenceProceedingReference.java
+++ b/src/main/java/io/github/codexrm/server/model/ConferenceProceedingReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "conferenceproceedingsreference")

--- a/src/main/java/io/github/codexrm/server/model/Reference.java
+++ b/src/main/java/io/github/codexrm/server/model/Reference.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "reference")

--- a/src/main/java/io/github/codexrm/server/model/RefreshToken.java
+++ b/src/main/java/io/github/codexrm/server/model/RefreshToken.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.Instant;
 
 @Entity(name = "refreshtoken")

--- a/src/main/java/io/github/codexrm/server/model/Role.java
+++ b/src/main/java/io/github/codexrm/server/model/Role.java
@@ -3,7 +3,7 @@ package io.github.codexrm.server.model;
 import io.github.codexrm.server.enums.ERole;
 import org.hibernate.annotations.NaturalId;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "rol")

--- a/src/main/java/io/github/codexrm/server/model/ThesisReference.java
+++ b/src/main/java/io/github/codexrm/server/model/ThesisReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "thesisreference")

--- a/src/main/java/io/github/codexrm/server/model/User.java
+++ b/src/main/java/io/github/codexrm/server/model/User.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/io/github/codexrm/server/model/WebPageReference.java
+++ b/src/main/java/io/github/codexrm/server/model/WebPageReference.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "webpagereference")

--- a/src/main/java/io/github/codexrm/server/payload/request/AddUserRequest.java
+++ b/src/main/java/io/github/codexrm/server/payload/request/AddUserRequest.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.payload.request;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public class AddUserRequest {

--- a/src/main/java/io/github/codexrm/server/payload/request/LoginRequest.java
+++ b/src/main/java/io/github/codexrm/server/payload/request/LoginRequest.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.payload.request;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 public class LoginRequest {
 

--- a/src/main/java/io/github/codexrm/server/payload/request/SignupRequest.java
+++ b/src/main/java/io/github/codexrm/server/payload/request/SignupRequest.java
@@ -1,8 +1,8 @@
 package io.github.codexrm.server.payload.request;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class SignupRequest {
 

--- a/src/main/java/io/github/codexrm/server/payload/request/TokenRefreshRequest.java
+++ b/src/main/java/io/github/codexrm/server/payload/request/TokenRefreshRequest.java
@@ -1,6 +1,6 @@
 package io.github.codexrm.server.payload.request;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 public class TokenRefreshRequest {
 

--- a/src/main/java/io/github/codexrm/server/security/WebSecurityConfig.java
+++ b/src/main/java/io/github/codexrm/server/security/WebSecurityConfig.java
@@ -3,48 +3,49 @@ package io.github.codexrm.server.security;
 import io.github.codexrm.server.security.jwt.AuthEntryPointJwt;
 import io.github.codexrm.server.security.jwt.AuthTokenFilter;
 import io.github.codexrm.server.security.services.UserDetailsServiceImpl;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
-@EnableGlobalMethodSecurity(
-        // securedEnabled = true,
-        // jsr250Enabled = true,
-        prePostEnabled = true)
-public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig {
 
-  @Autowired
-  UserDetailsServiceImpl userDetailsService;
+  private final UserDetailsServiceImpl userDetailsService;
+  private final AuthEntryPointJwt unauthorizedHandler;
 
-  @Autowired
-  private AuthEntryPointJwt unauthorizedHandler;
+  public WebSecurityConfig(UserDetailsServiceImpl userDetailsService,
+                           AuthEntryPointJwt unauthorizedHandler) {
+    this.userDetailsService = userDetailsService;
+    this.unauthorizedHandler = unauthorizedHandler;
+  }
 
   @Bean
   public AuthTokenFilter authenticationJwtTokenFilter() {
     return new AuthTokenFilter();
   }
 
-  @Override
-  public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
-    authenticationManagerBuilder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+  @Bean
+  public DaoAuthenticationProvider authenticationProvider() {
+    DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+    authProvider.setUserDetailsService(userDetailsService);
+    authProvider.setPasswordEncoder(passwordEncoder());
+    return authProvider;
   }
 
   @Bean
-  @Override
-  public AuthenticationManager authenticationManagerBean() throws Exception {
-    return super.authenticationManagerBean();
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig)
+          throws Exception {
+    return authConfig.getAuthenticationManager();
   }
 
   @Bean
@@ -52,16 +53,25 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     return new BCryptPasswordEncoder();
   }
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-    http.cors().and().csrf().disable()
-            .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-            .authorizeRequests().antMatchers("/api/auth/**").permitAll()
-            .antMatchers("/api/User/**").permitAll()
-            .antMatchers("/api/Reference/**").permitAll()
-            .anyRequest().authenticated();
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-    http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
+    http
+            .csrf(csrf -> csrf.disable())
+            .exceptionHandling(ex -> ex.authenticationEntryPoint(unauthorizedHandler))
+            .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers("/api/User/**").permitAll()
+                    .requestMatchers("/api/Reference/**").permitAll()
+                    .anyRequest().authenticated()
+            );
+
+    http.authenticationProvider(authenticationProvider());
+
+    http.addFilterBefore(authenticationJwtTokenFilter(),
+            UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
   }
 }

--- a/src/main/java/io/github/codexrm/server/security/jwt/AuthEntryPointJwt.java
+++ b/src/main/java/io/github/codexrm/server/security/jwt/AuthEntryPointJwt.java
@@ -6,9 +6,9 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component

--- a/src/main/java/io/github/codexrm/server/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/io/github/codexrm/server/security/jwt/AuthTokenFilter.java
@@ -11,10 +11,10 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class AuthTokenFilter extends OncePerRequestFilter {

--- a/src/main/java/io/github/codexrm/server/service/ReferenceService.java
+++ b/src/main/java/io/github/codexrm/server/service/ReferenceService.java
@@ -14,8 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityExistsException;
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/io/github/codexrm/server/service/UserService.java
+++ b/src/main/java/io/github/codexrm/server/service/UserService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;


### PR DESCRIPTION
- Replace javax with jakarta namespaces
- Migrate WebSecurityConfigurerAdapter to SecurityFilterChain
- Update to Spring Security 6
- Fix Lombok compatibility (Java 21)
- Resolve internal library dependency chain

Closes #32 
Related to:
- #33
- #34