### PR TITLE
feat: migrate project to Java 21 and Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>server</name>
 	<description>CodexRM API REST Server</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>21</java.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,10 +3,10 @@ spring.jpa.hibernate.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/CodexRM
+spring.datasource.url=jdbc:postgresql://localhost:5433/codexrm
 spring.datasource.driverClassName=org.postgresql.Driver
 spring.datasource.username=postgres
-spring.datasource.password=PostgreSQL
+spring.datasource.password=postgres
 spring.datasource.initialization-mode=always
 spring.datasource.initialize=true
 spring.datasource.continue-on-error=true


### PR DESCRIPTION
##  Migration to Java 21

This PR completes the migration of the project to Java 21 and aligns the application with Spring Boot 3.x requirements.

###  Changes Included

- Updated project to Java 21
- Migrated from `javax.*` to `jakarta.*`
- Updated Spring Boot to 3.2.5
- Updated Hibernate to 6.x
- Refactored Security configuration to use `SecurityFilterChain`
- Verified JWT authentication flow
- Ensured PostgreSQL connection via Docker
- Fixed deprecated and incompatible dependencies

### Validation

- Application builds successfully with Maven
- Application starts without runtime errors
- Database connection verified
- Security layer tested (JWT authentication working)
- Protected endpoints correctly return `401 Unauthorized` when no token is provided

###  Result

The project is now fully compatible with Java 21 and modern Spring Boot architecture, ready for containerization and further improvements.

 Closes #31 

Next step: Add Dockerfile and docker-compose for full containerized setup.