### PR TITLE
Remove springfox and unify with springdoc 2.x

### DIFF
--- a/src/main/java/io/github/codexrm/server/config/OpenApiConfig.java
+++ b/src/main/java/io/github/codexrm/server/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package io.github.codexrm.server.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI codexrmOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("CodexRM API")
+                        .description("Reference Manager API")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/io/github/codexrm/server/security/WebSecurityConfig.java
+++ b/src/main/java/io/github/codexrm/server/security/WebSecurityConfig.java
@@ -61,9 +61,14 @@ public class WebSecurityConfig {
             .exceptionHandling(ex -> ex.authenticationEntryPoint(unauthorizedHandler))
             .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/auth/**").permitAll()
-                    .requestMatchers("/api/User/**").permitAll()
-                    .requestMatchers("/api/Reference/**").permitAll()
+                    .requestMatchers(
+                            "/api/auth/**",
+                            "/api/User/**",
+                            "/api/Reference/**",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html",
+                            "/v3/api-docs/**"
+                    ).permitAll()
                     .anyRequest().authenticated()
             );
 


### PR DESCRIPTION
Replaced springfox with springdoc-openapi 2.x.

Changes:
- Removed springfox dependencies
- Added springdoc-openapi starter
- Added OpenApiConfig for API metadata
- Verified Swagger UI works correctly

Closes #36