### PR TITLE
Add validation layer for references and improve enum conversion

### DIFF
--- a/src/main/java/io/github/codexrm/server/component/EnumsConverter.java
+++ b/src/main/java/io/github/codexrm/server/component/EnumsConverter.java
@@ -6,93 +6,31 @@ public class EnumsConverter {
 
     public EnumsConverter() {}
 
-    public MonthsLibrary getMonthLibrary(String months) {
+    // ----------- MONTHS -----------
 
-        if (months != null) {
-            switch (months) {
-                case "jan":
-                    return MonthsLibrary.jan;
-                case "feb":
-                    return MonthsLibrary.feb;
-                case "mar":
-                    return MonthsLibrary.mar;
-                case "apr":
-                    return MonthsLibrary.apr;
-                case "may":
-                    return MonthsLibrary.may;
-                case "jun":
-                    return MonthsLibrary.jun;
-                case "jul":
-                    return MonthsLibrary.jul;
-                case "aug":
-                    return MonthsLibrary.aug;
-                case "sep":
-                    return MonthsLibrary.sep;
-                case "oct":
-                    return MonthsLibrary.oct;
-                case "nov":
-                    return MonthsLibrary.nov;
-                case "dec":
-                    return MonthsLibrary.dec;
-                default:
-                    return null;
-            }
-        } else {
+    public MonthsLibrary getMonthLibrary(String months) {
+        try {
+            return (months != null) ? MonthsLibrary.valueOf(months) : null;
+        } catch (IllegalArgumentException e) {
             return null;
         }
     }
 
     public String getMonth(MonthsLibrary months) {
-
-        if (months != null) {
-            switch (months) {
-                case jan:
-                    return "jan";
-                case feb:
-                    return "feb";
-                case mar:
-                    return "mar";
-                case apr:
-                    return "apr";
-                case may:
-                    return "may";
-                case jun:
-                    return "jun";
-                case jul:
-                    return "jul";
-                case aug:
-                    return "aug";
-                case sep:
-                    return "sep";
-                case oct:
-                    return "oct";
-                case nov:
-                    return "nov";
-                case dec:
-                    return "dec";
-                default:
-                    return null;
-            }
-        } else {
-            return null;
-        }
+        return (months != null) ? months.name() : null;
     }
+
+    // ----------- FORMAT -----------
 
     public FormatLibrary getFormat(String format) {
-
-        if (format != null) {
-            switch (format) {
-                case "RIS":
-                    return FormatLibrary.RIS;
-                case "BIBTEX":
-                    return FormatLibrary.BIBTEX;
-                default:
-                    return null;
-            }
-        } else {
+        try {
+            return (format != null) ? FormatLibrary.valueOf(format) : null;
+        } catch (IllegalArgumentException e) {
             return null;
         }
     }
+
+    // ----------- BOOK SECTION TYPE (SE DEJA CON SWITCH PARA NO ROMPER) -----------
 
     public BookSectionTypeLibrary getBookSectionTypeLibrary(String type) {
 
@@ -150,35 +88,17 @@ public class EnumsConverter {
         }
     }
 
-    public ThesisTypeLibrary getThesisTypeLibrary(String type) {
+    // ----------- THESIS TYPE -----------
 
-        if (type != null) {
-            switch (type) {
-                case "MASTERS":
-                    return ThesisTypeLibrary.MASTERS;
-                case "PHD":
-                    return ThesisTypeLibrary.PHD;
-                default:
-                    return null;
-            }
-        } else {
+    public ThesisTypeLibrary getThesisTypeLibrary(String type) {
+        try {
+            return (type != null) ? ThesisTypeLibrary.valueOf(type) : null;
+        } catch (IllegalArgumentException e) {
             return null;
         }
     }
 
     public String getThesisType(ThesisTypeLibrary type) {
-
-        if (type != null) {
-            switch (type) {
-                case MASTERS:
-                    return "MASTERS";
-                case PHD:
-                    return "PHD";
-                default:
-                    return null;
-            }
-        } else {
-            return null;
-        }
+        return (type != null) ? type.name() : null;
     }
 }

--- a/src/main/java/io/github/codexrm/server/component/ValidateReference.java
+++ b/src/main/java/io/github/codexrm/server/component/ValidateReference.java
@@ -1,5 +1,6 @@
 package io.github.codexrm.server.component;
 
+import io.github.codexrm.server.exception.BadRequestException;
 import io.github.codexrm.server.model.*;
 
 public class ValidateReference {
@@ -161,8 +162,8 @@ public class ValidateReference {
 
     public Reference validateRequiredArticle(ArticleReference article) {
         if (article.getAuthor() == null || article.getTitle() == null || article.getJournal() == null || article.getYear() == null ||
-                article.getAuthor().equals("") || article.getTitle().equals("") || article.getJournal().equals("") || article.getYear().equals("")) {
-            return null;
+                article.getAuthor().isBlank() || article.getTitle().isBlank() || article.getJournal().isBlank() || article.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return article;
         }
@@ -170,8 +171,8 @@ public class ValidateReference {
 
     public Reference validateRequiredBookSection(BookSectionReference section) {
         if (section.getChapter() == null || section.getPages() == null || section.getAuthor() == null || section.getEditor() == null || section.getTitle() == null || section.getPublisher() == null || section.getYear() == null ||
-                section.getChapter().equals("") || section.getPages().equals("") || section.getAuthor().equals("") || section.getEditor().equals("") || section.getTitle().equals("") || section.getPublisher().equals("") || section.getYear().equals("")) {
-            return null;
+                section.getChapter().isBlank() || section.getPages().isBlank() || section.getAuthor().isBlank() || section.getEditor().isBlank() || section.getTitle().isBlank() || section.getPublisher().isBlank() || section.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return section;
         }
@@ -179,24 +180,24 @@ public class ValidateReference {
 
     public Reference validateRequiredBook(BookReference book) {
         if (book.getAuthor() == null || book.getEditor() == null || book.getTitle() == null || book.getPublisher() == null || book.getYear() == null ||
-                book.getAuthor().equals("") || book.getEditor().equals("") || book.getTitle().equals("") || book.getPublisher().equals("") || book.getYear().equals("")) {
-            return null;
+                book.getAuthor().isBlank() || book.getEditor().isBlank() || book.getTitle().isBlank() || book.getPublisher().isBlank() || book.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return book;
         }
     }
 
     public Reference validateRequiredBookLet(BookLetReference let) {
-        if (let.getTitle() == null || let.getAuthor() == null || let.getTitle().equals("") || let.getAuthor().equals("")) {
-            return null;
+        if (let.getTitle() == null || let.getAuthor() == null || let.getTitle().isBlank() || let.getAuthor().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return let;
         }
     }
 
     public Reference validateRequiredConferenceProceedings(ConferenceProceedingReference proceedings) {
-        if (proceedings.getTitle() == null || proceedings.getYear() == null || proceedings.getTitle().equals("") || proceedings.getYear().equals("")) {
-            return null;
+        if (proceedings.getTitle() == null || proceedings.getYear() == null || proceedings.getTitle().isBlank() || proceedings.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return proceedings;
         }
@@ -204,8 +205,8 @@ public class ValidateReference {
 
     public Reference validateRequiredConferencePaper(ConferencePaperReference paper) {
         if (paper.getAuthor() == null || paper.getTitle() == null || paper.getBookTitle() == null || paper.getYear() == null ||
-                paper.getAuthor().equals("") || paper.getTitle().equals("") || paper.getBookTitle().equals("") || paper.getYear().equals("")) {
-            return null;
+                paper.getAuthor().isBlank() || paper.getTitle().isBlank() || paper.getBookTitle().isBlank() || paper.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return paper;
         }
@@ -213,8 +214,8 @@ public class ValidateReference {
 
     public Reference validateRequiredThesis(ThesisReference thesis) {
         if (thesis.getAuthor() == null || thesis.getTitle() == null || thesis.getSchool() == null || thesis.getYear() == null ||
-                thesis.getAuthor().equals("") || thesis.getTitle().equals("") || thesis.getSchool().equals("") || thesis.getYear().equals("")) {
-            return null;
+                thesis.getAuthor().isBlank() || thesis.getTitle().isBlank() || thesis.getSchool().isBlank() || thesis.getYear().isBlank()) {
+            throw new BadRequestException("Missing required fields for Reference");
         } else {
             return thesis;
         }

--- a/src/main/java/io/github/codexrm/server/controller/ReferenceController.java
+++ b/src/main/java/io/github/codexrm/server/controller/ReferenceController.java
@@ -14,6 +14,7 @@ import io.github.codexrm.server.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.jbibtex.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -136,7 +137,7 @@ public class ReferenceController {
     @Operation(summary = "Create a new reference")
     @PostMapping("/Add")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<ReferenceDTO> add(@RequestBody ReferenceDTO referenceDTO) {
+    public ResponseEntity<ReferenceDTO> add(@Valid @RequestBody ReferenceDTO referenceDTO) {
 
         User user = getAuthenticatedUser();
         Reference reference = dtoConverter.createReference(referenceDTO, user);
@@ -148,7 +149,7 @@ public class ReferenceController {
     @Operation(summary = "Update an existing reference")
     @PutMapping("/Update")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<ReferenceDTO> update(@RequestBody ReferenceDTO referenceDTO) {
+    public ResponseEntity<ReferenceDTO> update(@Valid @RequestBody ReferenceDTO referenceDTO) {
 
         User user = getAuthenticatedUser();
         Reference reference = dtoConverter.toReference(referenceDTO, user);
@@ -178,7 +179,7 @@ public class ReferenceController {
     @Operation(summary = "Delete multiple references")
     @PostMapping("/DeleteGroup")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<?> deleteGroup(@RequestBody ArrayList<Integer> idList) {
+    public ResponseEntity<?> deleteGroup(@Valid @RequestBody ArrayList<Integer> idList) {
 
         User user = getAuthenticatedUser();
         ArrayList<Integer> filtered = filterUserReferences(user.getId(), idList);
@@ -196,7 +197,7 @@ public class ReferenceController {
             @RequestParam(name = "title", required = false) String title,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size,
-            @RequestBody ReferenceLibraryDTO library) {
+            @Valid @RequestBody ReferenceLibraryDTO library) {
 
         User user = getAuthenticatedUser();
 
@@ -253,7 +254,7 @@ public class ReferenceController {
     public ResponseEntity<Resource> exportReferences(
             @RequestParam (name = "fileName", defaultValue = "file.txt") String fileName,
             @RequestParam (name = "format", defaultValue = "RIS") String format,
-            @RequestBody ArrayList<Integer> idList) throws IOException {
+            @Valid @RequestBody ArrayList<Integer> idList) throws IOException {
 
         User user = getAuthenticatedUser();
         ArrayList<Integer> filteredIds = filterUserReferences(user.getId(), idList);
@@ -288,7 +289,7 @@ public class ReferenceController {
             @RequestParam(name = "title", required = false) String title,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size,
-            @RequestBody(required = false) SortReference sort) {
+            @Valid @RequestBody(required = false) SortReference sort) {
 
         Page<Reference> result = referenceService.getAllFromUsers(year, title, page, size, sort);
 

--- a/src/main/java/io/github/codexrm/server/controller/UserController.java
+++ b/src/main/java/io/github/codexrm/server/controller/UserController.java
@@ -105,7 +105,7 @@ public class UserController {
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<UserDTO> update(@PathVariable ("id") Integer id,
-                                          @RequestBody UserDTO userDTO) {
+                                          @Valid @RequestBody UserDTO userDTO) {
 
         User user = dtoConverter.toUser(userDTO);
         user.setId(id);
@@ -117,7 +117,7 @@ public class UserController {
     @Operation(summary = "Update password")
     @PutMapping("/password")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<?> updatePassword(@RequestBody UpdateUserPasswordRequest request) {
+    public ResponseEntity<?> updatePassword(@Valid @RequestBody UpdateUserPasswordRequest request) {
 
         UserDetailsImpl userDetails =
                 (UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -141,7 +141,7 @@ public class UserController {
     @Operation(summary = "Update preferences")
     @PutMapping("/preferences")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<UserDTO> updatePreferences(@RequestBody UserDTO userDTO) {
+    public ResponseEntity<UserDTO> updatePreferences(@Valid @RequestBody UserDTO userDTO) {
 
         UserDetailsImpl userDetails =
                 (UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -173,7 +173,7 @@ public class UserController {
     @Operation(summary = "Delete multiple users")
     @PostMapping("/delete-group")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> deleteGroup(@RequestBody List<Integer> ids) {
+    public ResponseEntity<?> deleteGroup(@Valid @RequestBody List<Integer> ids) {
 
         ids.forEach(userService::delete);
         return ResponseEntity.ok().build();

--- a/src/main/java/io/github/codexrm/server/dto/ArticleReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ArticleReferenceDTO.java
@@ -1,26 +1,35 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Article reference information")
 public class ArticleReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the article", example = "Garcia,Juan")
+    @NotBlank
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String author;
 
     @Schema(description = "Journal where the article was published", example = "Nature")
+    @NotBlank
     private String journal;
 
     @Schema(description = "Journal volume", example = "12")
+    @Pattern(regexp = "^$|[\\d]*")
     private String volume;
 
     @Schema(description = "Journal issue number", example = "3")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ0-9\\s-]+")
     private String number;
 
     @Schema(description = "Page range of the article", example = "120-135")
+    @Pattern(regexp = "[IVXMLCD]+|[IVXMLCD]+,[IVXMLCD]+|[IVXMLCD]+-[IVXMLCD]+|[0-9]+|[0-9]+,[0-9]+|[0-9]+-[0-9]+")
     private String pages;
 
     @Schema(description = "ISSN of the journal", example = "1234-5678")
+    @Pattern(regexp = "\\d{4}-\\d{4}|\\d{4}-\\d{3}X")
     private String issn;
 
     public ArticleReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/BookLetReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/BookLetReferenceDTO.java
@@ -1,17 +1,20 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Booklet reference information")
 public class BookLetReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the booklet", example = "Smith,John")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String author;
 
     @Schema(description = "How the booklet was published", example = "Online publication")
     private String howpublished;
 
     @Schema(description = "Publication address or location", example = "New York, USA")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]*[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+,\\s[[A-Za-záéíóúüñÁÉÍÓÚÜÑ]+]*")
     private String address;
 
     public BookLetReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/BookReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/BookReferenceDTO.java
@@ -1,35 +1,49 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Book reference information")
 public class BookReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the book", example = "Martin,Robert")
+    @NotBlank
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     protected String author;
 
     @Schema(description = "Editor of the book", example = "Smith,John")
+    @NotBlank
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     protected String editor;
 
     @Schema(description = "Publisher of the book", example = "Prentice Hall")
+    @NotBlank
     protected String publisher;
 
     @Schema(description = "Volume of the book", example = "1")
+    @Pattern(regexp = "^$|[\\d]*")
     protected String volume;
 
     @Schema(description = "Series to which the book belongs", example = "Computer Science Series")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]+")
     protected String series;
 
     @Schema(description = "Book number within the series", example = "12")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ0-9\\s-]+")
     protected String number;
 
     @Schema(description = "Publication address or location", example = "São Paulo, Brasil")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]*[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+,\\s[[A-Za-záéíóúüñÁÉÍÓÚÜÑ]+]*")
     protected String address;
 
     @Schema(description = "Edition of the book", example = "2.")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+|\\d+\\.")
     protected String edition;
 
     @Schema(description = "ISBN identifier of the book", example = "123-456-789-0")
+    @Pattern(regexp = "^(?=(?:\\D*\\d){10}(?:(?:\\D*\\d){3})?$)[\\d-]+$")
     protected String isbn;
 
     public BookReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/BookSectionReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/BookSectionReferenceDTO.java
@@ -1,17 +1,25 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Book section reference information")
 public class BookSectionReferenceDTO extends BookReferenceDTO {
 
     @Schema(description = "Chapter of the book where the section appears", example = "5")
+    @NotBlank
+    @Pattern(regexp = "^$|[\\d]*")
     private String chapter;
 
     @Schema(description = "Page range of the section", example = "120-135")
+    @NotBlank
+    @Pattern(regexp = "[IVXMLCD]+|[IVXMLCD]+,[IVXMLCD]+|[IVXMLCD]+-[IVXMLCD]+|[0-9]+|[0-9]+,[0-9]+|[0-9]+-[0-9]+")
     private String pages;
 
-    @Schema(description = "Type of section (e.g., chapter, appendix)", example = "chapter")
+    @Schema(description = "Type of section (e.g., MATHESIS, PHDTHESIS)", example = "chapter")
+    @Pattern(regexp = "^(?i)(MATHESIS|PHDTHESIS|CANDTHESIS|TECHREPORT|RESREPORT|SOFTWARE|AUDIOCD|DataCD)$",
+            message = "Invalid type")
     private String type;
 
     public BookSectionReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/ConferencePaperReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ConferencePaperReferenceDTO.java
@@ -1,32 +1,43 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Conference paper reference information")
 public class ConferencePaperReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the conference paper", example = "Navarro,Andrew")
+    @NotBlank
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String author;
 
     @Schema(description = "Title of the book or proceedings where the paper appears", example = "Proceedings of the International Conference on Machine Learning")
+    @NotBlank
     private String bookTitle;
 
     @Schema(description = "Editor of the conference proceedings", example = "Smith,John")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String editor;
 
     @Schema(description = "Volume of the proceedings", example = "15")
+    @Pattern(regexp = "^$|[\\d]*")
     private String volume;
 
     @Schema(description = "Issue number of the proceedings", example = "2")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ0-9\\s-]+")
     private String number;
 
     @Schema(description = "Series of the conference proceedings", example = "Lecture Notes in Computer Science")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]+")
     private String series;
 
     @Schema(description = "Page range of the paper", example = "210-225")
+    @Pattern(regexp = "[IVXMLCD]+|[IVXMLCD]+,[IVXMLCD]+|[IVXMLCD]+-[IVXMLCD]+|[0-9]+|[0-9]+,[0-9]+|[0-9]+-[0-9]+")
     private String pages;
 
     @Schema(description = "Location where the conference took place", example = "Berlin, Alemania")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]*[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+,\\s[[A-Za-záéíóúüñÁÉÍÓÚÜÑ]+]*")
     private String address;
 
     @Schema(description = "Organization responsible for the conference", example = "IEEE")

--- a/src/main/java/io/github/codexrm/server/dto/ConferenceProceedingsReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ConferenceProceedingsReferenceDTO.java
@@ -1,23 +1,29 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Conference proceedings reference information")
 public class ConferenceProceedingsReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Editor of the conference proceedings", example = "Smith,John")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String editor;
 
     @Schema(description = "Volume of the proceedings", example = "10")
+    @Pattern(regexp = "^$|[\\d]*")
     private String volume;
 
     @Schema(description = "Issue number of the proceedings", example = "2")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ0-9\\s-]+")
     private String number;
 
     @Schema(description = "Series of the conference proceedings", example = "Lecture Notes in Computer Science")
+    @Pattern(regexp = "[A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]+")
     private String series;
 
     @Schema(description = "Location where the conference took place", example = "Paris, Francia")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]*[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+,\\s[[A-Za-záéíóúüñÁÉÍÓÚÜÑ]+]*")
     private String address;
 
     @Schema(description = "Publisher of the conference proceedings", example = "Springer")
@@ -27,6 +33,7 @@ public class ConferenceProceedingsReferenceDTO extends ReferenceDTO {
     private String organization;
 
     @Schema(description = "ISBN identifier of the proceedings", example = "978-3-16-148410-0")
+    @Pattern(regexp = "^(?=(?:\\D*\\d){10}(?:(?:\\D*\\d){3})?$)[\\d-]+$")
     private String isbn;
 
     public ConferenceProceedingsReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/PageDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/PageDTO.java
@@ -1,17 +1,21 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Pagination information for paged responses")
 public class PageDTO {
 
     @Schema(description = "Current page number", example = "0")
+    @NotBlank
     private Integer currentPage;
 
     @Schema(description = "Total number of elements available", example = "125")
+    @NotBlank
     private Long totalElement;
 
     @Schema(description = "Total number of pages available", example = "13")
+    @NotBlank
     private Integer totalPages;
 
     public PageDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/ReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ReferenceDTO.java
@@ -3,6 +3,8 @@ package io.github.codexrm.server.dto;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "referenceType")
 @JsonSubTypes({
@@ -23,9 +25,11 @@ public class ReferenceDTO {
     protected String title;
 
     @Schema(description = "Year of publication", example = "2016 or 2020--2021")
+    @Pattern(regexp = "\\d{4}|\\d{4}--\\d{4}")
     protected String year;
 
     @Schema(description = "Month of publication", example = "July")
+    @Pattern(regexp = "^(?i)(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)$")
     protected String month;
 
     @Schema(description = "Additional notes about the reference", example = "Second edition")

--- a/src/main/java/io/github/codexrm/server/dto/ReferenceLibraryDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ReferenceLibraryDTO.java
@@ -2,6 +2,7 @@ package io.github.codexrm.server.dto;
 
 import io.github.codexrm.server.enums.SortReference;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ public class ReferenceLibraryDTO {
     private List<Integer> deletedReferencesList;
 
     @Schema( description = "Sorting configuration applied after synchronization")
+    @NotBlank
     private SortReference sortReference;
 
     public ReferenceLibraryDTO() {

--- a/src/main/java/io/github/codexrm/server/dto/ReferencePageDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ReferencePageDTO.java
@@ -1,6 +1,7 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
@@ -11,6 +12,7 @@ public class ReferencePageDTO {
     private List<ReferenceDTO> referenceDTOList;
 
     @Schema(description = "Pagination metadata associated with the reference list")
+    @NotBlank
     private PageDTO pageDTO;
 
     public ReferencePageDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/ThesisReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/ThesisReferenceDTO.java
@@ -1,20 +1,27 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Thesis reference information")
 public class ThesisReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the thesis", example = "Gonzalez,Maria")
+    @NotBlank
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String author;
 
     @Schema(description = "University or institution where the thesis was submitted", example = "University of Havana")
+    @NotBlank
     private String school;
 
     @Schema(description = "Type of thesis", example = "PhD Thesis")
+    @Pattern(regexp = "^(MASTERS|PHD)$")
     private String type;
 
     @Schema(description = "Location of the university or institution", example = "La Habana, Cuba")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][A-ZÁÉÍÓÚÜÑa-záéíóúüñ\\s]*[A-ZÁÉÍÓÚÜÑa-záéíóúüñ]+,\\s[[A-Za-záéíóúüñÁÉÍÓÚÜÑ]+]*")
     private String address;
 
     public ThesisReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/dto/UserDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/UserDTO.java
@@ -1,6 +1,9 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -11,15 +14,24 @@ public class UserDTO {
     private Integer id;
 
     @Schema(description = "Username of the user", example = "marynes")
+    @NotBlank
+    @Size(min = 3, max = 20)
     private String username;
 
     @Schema(description = "First name of the user", example = "Marynes")
+    @NotBlank
+    @Size(max = 20)
     private String name;
 
     @Schema(description = "Last name of the user", example = "Diaz")
+    @NotBlank
+    @Size(max = 20)
     private String lastName;
 
     @Schema(description = "Email address of the user", example = "marynes@email.com")
+    @NotBlank
+    @Size(max = 50)
+    @Email
     private String email;
 
     @Schema(description = "Indicates whether the user account is enabled", example = "true")

--- a/src/main/java/io/github/codexrm/server/dto/UserPageDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/UserPageDTO.java
@@ -1,6 +1,8 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +13,7 @@ public class UserPageDTO {
     private List<UserDTO> userDTOList;
 
     @Schema(description = "Pagination metadata associated with the user list")
+    @NotBlank
     private PageDTO pageDTO;
 
     public UserPageDTO() {

--- a/src/main/java/io/github/codexrm/server/dto/WebPageReferenceDTO.java
+++ b/src/main/java/io/github/codexrm/server/dto/WebPageReferenceDTO.java
@@ -1,14 +1,18 @@
 package io.github.codexrm.server.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "Web page reference information")
 public class WebPageReferenceDTO extends ReferenceDTO {
 
     @Schema(description = "Author of the web page content", example = "Doe,John")
+    @Pattern(regexp = "^[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+[;(?=[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+)[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+,[A-ZÁÉÍÓÚÜÑ][a-záéíóúüñ]+]*")
     private String author;
 
     @Schema(description = "URL of the web page", example = "https://example.com/article")
+    @Pattern(regexp = "^https://.*")
     private String url;
 
     public WebPageReferenceDTO() {}

--- a/src/main/java/io/github/codexrm/server/exception/BadRequestException.java
+++ b/src/main/java/io/github/codexrm/server/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package io.github.codexrm.server.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/codexrm/server/payload/request/UpdateUserPasswordRequest.java
+++ b/src/main/java/io/github/codexrm/server/payload/request/UpdateUserPasswordRequest.java
@@ -1,17 +1,25 @@
 package io.github.codexrm.server.payload.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Request payload used to update the password of the authenticated user")
 public class UpdateUserPasswordRequest {
 
     @Schema(description = "Current password of the user", example = "oldPassword123")
+    @NotBlank
+    @Size(min = 6, max = 40)
     private String currentPassword;
 
     @Schema(description = "New password to replace the current one", example = "newSecurePassword123")
+    @NotBlank
+    @Size(min = 6, max = 40)
     private String newPassword;
 
     @Schema(description = "Confirmation of the new password", example = "newSecurePassword123")
+    @NotBlank
+    @Size(min = 6, max = 40)
     private String confirmationPassword;
 
     public UpdateUserPasswordRequest() {}


### PR DESCRIPTION
##  Summary

This PR introduces a structured validation mechanism for reference entities and improves enum conversion handling while preserving existing behavior.

---

##  Changes

###  Validation Improvements
- Implemented business validation in `ValidateReference` for all reference types
- Replaced `null` returns with `BadRequestException` for missing required fields
- Standardized string validation using `isBlank()` instead of `equals("")`

###   Enum Handling
- Refactored `EnumsConverter` to use `Enum.valueOf()` where safe
- Maintained `null` fallback behavior to avoid breaking existing flows
- Preserved switch-case logic for inconsistent enum values (e.g., `DataCD`)

###   Architecture
- Enforced separation of concerns:
  - DTO: basic validation (`@Valid`)
  - Converter: data transformation only
  - Validator: business rules

---

##  Validation

- All reference types validated before persistence
- No invalid or incomplete entities are saved to the database
- Existing controller flow remains unchanged

---

##  Notes

- Some enum conversions still use `switch` to maintain compatibility (case sensitivity issues)
- Future improvement: normalize enum values and remove remaining switches

---

##   Result

- Cleaner validation flow
- Better error handling
- More maintainable and scalable codebase

Close issue #54