### PR TITLE
test(unit): add initial unit tests as safety net before refactoring

### DIFF
--- a/src/test/java/component/FieldValidationsTest.java
+++ b/src/test/java/component/FieldValidationsTest.java
@@ -1,0 +1,164 @@
+package component;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import io.github.codexrm.server.component.FieldValidations;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FieldValidationsTest {
+
+    private FieldValidations validations;
+
+    @BeforeEach
+    void setUp() {
+        validations = new FieldValidations();
+    }
+    // ===================== YEAR =====================
+
+    @Test
+    void shouldAcceptValidYear() {
+        assertFalse(validations.isInvalidateYear("2024"));
+    }
+
+    @Test
+    void shouldAcceptValidYearRange() {
+        assertFalse(validations.isInvalidateYear("2020--2024"));
+    }
+
+    @Test
+    void shouldRejectInvalidYear() {
+        assertTrue(validations.isInvalidateYear("20a4"));
+    }
+
+    // ===================== AUTHOR / EDITOR =====================
+
+    @Test
+    void shouldAcceptValidAuthor() {
+        assertFalse(validations.isInvalidateAuthorOrEditor("Garcia,Juan"));
+    }
+
+    @Test
+    void shouldAcceptMultipleAuthors() {
+        assertFalse(validations.isInvalidateAuthorOrEditor("Garcia,Juan;Perez,Ana"));
+    }
+
+    @Test
+    void shouldRejectInvalidAuthor() {
+        assertTrue(validations.isInvalidateAuthorOrEditor("juan garcia"));
+    }
+
+    // ===================== VOLUME / CHAPTER =====================
+
+    @Test
+    void shouldAcceptValidVolume() {
+        assertFalse(validations.isInvalidateChapterOrVolume("12"));
+    }
+
+    @Test
+    void shouldRejectInvalidVolume() {
+        assertTrue(validations.isInvalidateChapterOrVolume("abc"));
+    }
+
+    // ===================== NUMBER =====================
+
+    @Test
+    void shouldAcceptValidNumber() {
+        assertFalse(validations.isInvalidateNumber("12A"));
+    }
+
+    @Test
+    void shouldRejectInvalidNumber() {
+        assertTrue(validations.isInvalidateNumber("@@@"));
+    }
+
+    // ===================== PAGES =====================
+
+    @Test
+    void shouldAcceptValidPages() {
+        assertFalse(validations.isInvalidatePages("10-20"));
+    }
+
+    @Test
+    void shouldAcceptRomanPages() {
+        assertFalse(validations.isInvalidatePages("X-XX"));
+    }
+
+    @Test
+    void shouldRejectInvalidPages() {
+        assertTrue(validations.isInvalidatePages("pages"));
+    }
+
+    // ===================== ISSN =====================
+
+    @Test
+    void shouldAcceptValidIssn() {
+        assertFalse(validations.isInvalidateIssn("1234-5678"));
+    }
+
+    @Test
+    void shouldRejectInvalidIssn() {
+        assertTrue(validations.isInvalidateIssn("123"));
+    }
+
+    // ===================== ISBN =====================
+
+    @Test
+    void shouldAcceptValidIsbn() {
+        assertFalse(validations.isInvalidateIsbn("978-3-16-148410-0"));
+    }
+
+    @Test
+    void shouldRejectInvalidIsbn() {
+        assertTrue(validations.isInvalidateIsbn("invalid-isbn"));
+    }
+
+    // ===================== ADDRESS =====================
+
+    @Test
+    void shouldAcceptValidAddress() {
+        assertFalse(validations.isInvalidateAddress("Madrid, España"));
+    }
+
+    @Test
+    void shouldRejectInvalidAddress() {
+        assertTrue(validations.isInvalidateAddress("1234"));
+    }
+
+    // ===================== SERIES =====================
+
+    @Test
+    void shouldAcceptValidSeries() {
+        assertFalse(validations.isInvalidateSeries("Spring Series"));
+    }
+
+    @Test
+    void shouldRejectInvalidSeries() {
+        assertTrue(validations.isInvalidateSeries("1234"));
+    }
+
+    // ===================== EDITION =====================
+
+    @Test
+    void shouldAcceptValidEdition() {
+        assertFalse(validations.isInvalidateEdition("Second"));
+    }
+
+    @Test
+    void shouldRejectInvalidEdition() {
+        assertTrue(validations.isInvalidateEdition("@@@"));
+    }
+
+    // ===================== URL =====================
+
+    @Test
+    void shouldAcceptValidUrl() {
+        assertFalse(validations.isInvalidateUrl("https://example.com"));
+    }
+
+    @Test
+    void shouldRejectInvalidUrl() {
+        assertTrue(validations.isInvalidateUrl("htp://bad-url"));
+    }
+}
+

--- a/src/test/java/service/ReferenceServiceTest.java
+++ b/src/test/java/service/ReferenceServiceTest.java
@@ -1,0 +1,199 @@
+package service;
+
+import io.github.codexrm.server.exception.ResourceNotFoundException;
+import io.github.codexrm.server.model.Reference;
+import io.github.codexrm.server.model.User;
+import io.github.codexrm.server.repository.ReferenceRepository;
+import io.github.codexrm.server.service.ReferenceService;
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ReferenceServiceTest {
+
+    @Mock
+    private ReferenceRepository referenceRepository;
+
+    @InjectMocks
+    private ReferenceService referenceService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        user = new User();
+        user.setId(1);
+    }
+
+    // =========================
+    // TEST: get()
+    // =========================
+
+    @Test
+    void shouldReturnReference_whenExists() {
+        Reference ref = new Reference();
+        ref.setId(1);
+
+        when(referenceRepository.findById(1)).thenReturn(Optional.of(ref));
+
+        Reference result = referenceService.get(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.getId());
+    }
+
+    @Test
+    void shouldThrowException_whenReferenceNotFound() {
+        when(referenceRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> referenceService.get(1));
+    }
+
+    // =========================
+    // TEST: getAll()
+    // =========================
+
+    @Test
+    void shouldReturnAll_whenNoFilters() {
+        Page<Reference> page = new PageImpl<>(List.of(new Reference()));
+
+        when(referenceRepository.findByUser(eq(user), any(Pageable.class))).thenReturn(page);
+
+        Page<Reference> result = referenceService.getAll(user, null, null, 0, 10, null);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterByTitle() {
+        Page<Reference> page = new PageImpl<>(List.of(new Reference()));
+
+        when(referenceRepository.findByUserAndTitleContaining(eq(user), eq("test"), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<Reference> result = referenceService.getAll(user, null, "test", 0, 10, null);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterByYear() {
+        Page<Reference> page = new PageImpl<>(List.of(new Reference()));
+
+        when(referenceRepository.findByUserAndYearContaining(eq(user), eq("2024"), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<Reference> result = referenceService.getAll(user, "2024", null, 0, 10, null);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterByYearAndTitle() {
+        Page<Reference> page = new PageImpl<>(List.of(new Reference()));
+
+        when(referenceRepository.findByUserAndYearContainingAndTitleContaining(
+                eq(user), eq("2024"), eq("test"), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<Reference> result = referenceService.getAll(user, "2024", "test", 0, 10, null);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyPage() {
+        when(referenceRepository.findByUser(eq(user), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        Page<Reference> result = referenceService.getAll(user, null, null, 0, 10, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // =========================
+    // TEST: add()
+    // =========================
+
+    @Test
+    void shouldSaveReference() {
+        Reference ref = new Reference();
+
+        when(referenceRepository.save(ref)).thenReturn(ref);
+
+        Reference result = referenceService.add(ref);
+
+        assertNotNull(result);
+        verify(referenceRepository).save(ref);
+    }
+
+    @Test
+    void shouldThrowException_whenReferenceAlreadyExists() {
+        Reference ref = new Reference();
+        ref.setId(1);
+
+        when(referenceRepository.existsById(1)).thenReturn(true);
+
+        assertThrows(EntityExistsException.class, () -> referenceService.add(ref));
+    }
+
+    // =========================
+    // TEST: update()
+    // =========================
+
+    @Test
+    void shouldUpdateReference_whenExists() {
+        Reference ref = new Reference();
+        ref.setId(1);
+
+        when(referenceRepository.existsById(1)).thenReturn(true);
+        when(referenceRepository.save(ref)).thenReturn(ref);
+
+        Reference result = referenceService.update(ref);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldThrowException_whenUpdatingNonExistingReference() {
+        Reference ref = new Reference();
+        ref.setId(1);
+
+        when(referenceRepository.existsById(1)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> referenceService.update(ref));
+    }
+
+    // =========================
+    // TEST: delete()
+    // =========================
+
+    @Test
+    void shouldDeleteReference_whenExists() {
+        when(referenceRepository.existsById(1)).thenReturn(true);
+
+        referenceService.delete(1);
+
+        verify(referenceRepository).deleteById(1);
+    }
+
+    @Test
+    void shouldThrowException_whenDeletingNonExistingReference() {
+        when(referenceRepository.existsById(1)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> referenceService.delete(1));
+    }
+}

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -1,0 +1,183 @@
+package service;
+
+import io.github.codexrm.server.model.User;
+import io.github.codexrm.server.repository.RoleRepository;
+import io.github.codexrm.server.repository.UserRepository;
+import io.github.codexrm.server.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.data.domain.*;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // =========================
+    // TEST: get()
+    // =========================
+
+    @Test
+    void shouldReturnUser_whenUserExists() {
+        User user = new User();
+        user.setId(1);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+        User result = userService.get(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.getId());
+    }
+
+    @Test
+    void shouldThrowException_whenUserNotExists() {
+        when(userRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> userService.get(1));
+    }
+
+    // =========================
+    // TEST: getAll()
+    // =========================
+
+    @Test
+    void shouldReturnPage_whenUsernameIsNull() {
+        Page<User> page = new PageImpl<>(java.util.List.of(new User()));
+
+        when(userRepository.findAll(any(Pageable.class))).thenReturn(page);
+
+        Page<User> result = userService.getAll(null, 0, 10, null);
+
+        assertNotNull(result);
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    void shouldReturnFilteredPage_whenUsernameProvided() {
+        Page<User> page = new PageImpl<>(java.util.List.of(new User()));
+
+        when(userRepository.findByUsernameContaining(eq("john"), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<User> result = userService.getAll("john", 0, 10, null);
+
+        assertNotNull(result);
+        assertEquals(1, result.getContent().size());
+    }
+
+    // =========================
+    // TEST: add()
+    // =========================
+
+    @Test
+    void shouldSaveUser() {
+        User user = new User();
+
+        when(userRepository.save(user)).thenReturn(user);
+
+        User result = userService.add(user);
+
+        assertNotNull(result);
+        verify(userRepository).save(user);
+    }
+
+    // =========================
+    // TEST: update()
+    // =========================
+
+    @Test
+    void shouldUpdateUser_whenExists() {
+        User user = new User();
+        user.setId(1);
+
+        when(userRepository.existsById(1)).thenReturn(true);
+        when(userRepository.save(user)).thenReturn(user);
+
+        User result = userService.update(user);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldThrowException_whenUpdatingNonExistingUser() {
+        User user = new User();
+        user.setId(1);
+
+        when(userRepository.existsById(1)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> userService.update(user));
+    }
+
+    // =========================
+    // TEST: delete()
+    // =========================
+
+    @Test
+    void shouldDeleteUser_whenExists() {
+        when(userRepository.existsById(1)).thenReturn(true);
+
+        userService.delete(1);
+
+        verify(userRepository).deleteById(1);
+    }
+
+    @Test
+    void shouldThrowException_whenDeletingNonExistingUser() {
+        when(userRepository.existsById(1)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> userService.delete(1));
+    }
+
+    // =========================
+    // TEST: validateUser()
+    // =========================
+
+    @Test
+    void shouldThrowException_whenUsernameExists() {
+        when(userRepository.existsByUsername("john")).thenReturn(true);
+
+        assertThrows(RuntimeException.class, () ->
+                userService.validateUser("john", "email@test.com"));
+    }
+
+    @Test
+    void shouldThrowException_whenEmailExists() {
+        when(userRepository.existsByUsername("john")).thenReturn(false);
+        when(userRepository.existsByEmail("email@test.com")).thenReturn(true);
+
+        assertThrows(RuntimeException.class, () ->
+                userService.validateUser("john", "email@test.com"));
+    }
+
+    @Test
+    void shouldPassValidation_whenUserIsValid() {
+        when(userRepository.existsByUsername("john")).thenReturn(false);
+        when(userRepository.existsByEmail("email@test.com")).thenReturn(false);
+
+        assertDoesNotThrow(() ->
+                userService.validateUser("john", "email@test.com"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds initial unit tests to provide a safety net before upcoming refactoring.

## Scope

The following components are covered:

- FieldValidations
- UserService
- ReferenceService

## What was done

- Implemented unit tests using JUnit 5 and Mockito
- Covered valid and invalid scenarios
- Tested service layer logic including:
  - Entity retrieval
  - Filtering and pagination
  - Exception handling
- Verified behavior without modifying existing code

## Technical Details

- Used @Mock and @InjectMocks for isolation
- No database interaction (pure unit tests)
- Ensured compatibility with current implementation

closes issue #58 


