### PR TITLE
refactor: extract role resolution to RoleService

### DIFF
--- a/src/main/java/io/github/codexrm/server/component/DTOConverter.java
+++ b/src/main/java/io/github/codexrm/server/component/DTOConverter.java
@@ -1,9 +1,8 @@
 package io.github.codexrm.server.component;
 
 import io.github.codexrm.server.dto.*;
-import io.github.codexrm.server.enums.ERole;
 import io.github.codexrm.server.model.*;
-import io.github.codexrm.server.repository.RoleRepository;
+import io.github.codexrm.server.service.RoleService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -15,13 +14,13 @@ import java.util.List;
 public class DTOConverter {
 
     private final ModelMapper modelMapper;
-    private final RoleRepository roleRepository;
+    private final RoleService roleService;
     private final ValidateReference validation;
 
     @Autowired
-    public DTOConverter(ModelMapper modelMapper, RoleRepository roleRepository) {
+    public DTOConverter(ModelMapper modelMapper, RoleService roleService) {
         this.modelMapper = modelMapper;
-        this.roleRepository = roleRepository;
+        this.roleService = roleService;
         this.validation = new ValidateReference();
     }
 
@@ -163,35 +162,7 @@ public class DTOConverter {
 
         User user = modelMapper.map(userDTO, User.class);
         user.getRoles().clear();
-
-        for (String role : userDTO.getRoles()) {
-            user.setRole(getRole(role));
-        }
-
+        user.setRoles(roleService.resolveRoles(userDTO.getRoles()));
         return user;
-    }
-
-    // =========================
-    // ====== HELPERS ==========
-    // =========================
-
-    private Role getRole(String role) {
-        return switch (role) {
-            case "ROLE_ADMIN" ->
-                    roleRepository.findByName(ERole.ROLE_ADMIN)
-                            .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
-
-            case "ROLE_MANAGER" ->
-                    roleRepository.findByName(ERole.ROLE_MANAGER)
-                            .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
-
-            case "ROLE_AUDITOR" ->
-                    roleRepository.findByName(ERole.ROLE_AUDITOR)
-                            .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
-
-            default ->
-                    roleRepository.findByName(ERole.ROLE_USER)
-                            .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
-        };
     }
 }

--- a/src/main/java/io/github/codexrm/server/service/RoleService.java
+++ b/src/main/java/io/github/codexrm/server/service/RoleService.java
@@ -1,0 +1,48 @@
+package io.github.codexrm.server.service;
+
+import io.github.codexrm.server.enums.ERole;
+import io.github.codexrm.server.exception.ResourceNotFoundException;
+import io.github.codexrm.server.model.Role;
+import io.github.codexrm.server.repository.RoleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class RoleService {
+
+    private final RoleRepository roleRepository;
+
+    public RoleService(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    public Set<Role> resolveRoles(List<String> roleNames) {
+
+        Set<Role> roles = new HashSet<>();
+
+        if (roleNames == null || roleNames.isEmpty()) {
+            roles.add(getRoleOrThrow(ERole.ROLE_USER));
+            return roles;
+        }
+        
+        for (String roleName : roleNames) {
+            try {
+                ERole eRole = ERole.valueOf(roleName);
+                roles.add(getRoleOrThrow(eRole));
+            } catch (IllegalArgumentException e) {
+                throw new ResourceNotFoundException("Role", "name", roleName);
+            }
+        }
+
+        return roles;
+    }
+
+    private Role getRoleOrThrow(ERole role) {
+        return roleRepository.findByName(role)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", "name", role.name()));
+    }
+
+}

--- a/src/main/java/io/github/codexrm/server/service/UserService.java
+++ b/src/main/java/io/github/codexrm/server/service/UserService.java
@@ -1,19 +1,16 @@
 package io.github.codexrm.server.service;
 
-import io.github.codexrm.server.enums.ERole;
 import io.github.codexrm.server.enums.SortUser;
 import io.github.codexrm.server.exception.DuplicateResourceException;
 import io.github.codexrm.server.exception.InvalidOperationException;
 import io.github.codexrm.server.exception.ResourceNotFoundException;
 import io.github.codexrm.server.model.Role;
 import io.github.codexrm.server.model.User;
-import io.github.codexrm.server.repository.RoleRepository;
 import io.github.codexrm.server.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -21,12 +18,12 @@ import java.util.Set;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final RoleRepository roleRepository;
+    private final RoleService roleService;
 
     @Autowired
-    public UserService(final UserRepository userRepository, RoleRepository roleRepository) {
+    public UserService(final UserRepository userRepository, RoleService roleService) {
         this.userRepository = userRepository;
-        this.roleRepository = roleRepository;
+        this.roleService = roleService;
     }
 
     public Page<User> getAll(String username, int page, int size, SortUser sort) {
@@ -84,44 +81,16 @@ public class UserService {
 
     public User createUserAccount(User user, boolean isUser, List<String> roleList) {
 
-        Set<Role> roles = new HashSet<>();
+        Set<Role> roles;
 
         if (isUser) {
-            roles.add(getRole(ERole.ROLE_USER));
-
+            roles = roleService.resolveRoles(List.of("ROLE_USER"));
         } else {
-            if (roleList == null) {
-                roles.add(getRole(ERole.ROLE_USER));
-
-            } else {
-                roleList.forEach(role -> {
-                    switch (role) {
-                        case "ROLE_ADMIN":
-                            roles.add(getRole(ERole.ROLE_ADMIN));
-                            break;
-
-                        case "ROLE_MANAGER":
-                            roles.add(getRole(ERole.ROLE_MANAGER));
-                            break;
-
-                        case "ROLE_AUDITOR":
-                            roles.add(getRole(ERole.ROLE_AUDITOR));
-                            break;
-
-                        default:
-                            roles.add(getRole(ERole.ROLE_USER));
-                    }
-                });
-            }
+            roles = roleService.resolveRoles(roleList);
         }
 
         user.setRoles(roles);
         return add(user);
-    }
-
-    private Role getRole(ERole role) {
-        return roleRepository.findByName(role)
-                .orElseThrow(() -> new ResourceNotFoundException("Role", "name", role));
     }
 
     private Sort.Order getOrder(SortUser sort) {

--- a/src/test/java/service/RoleServiceTest.java
+++ b/src/test/java/service/RoleServiceTest.java
@@ -1,0 +1,107 @@
+package service;
+
+import io.github.codexrm.server.enums.ERole;
+import io.github.codexrm.server.exception.ResourceNotFoundException;
+import io.github.codexrm.server.model.Role;
+import io.github.codexrm.server.repository.RoleRepository;
+import io.github.codexrm.server.service.RoleService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoleServiceTest {
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @InjectMocks
+    private RoleService roleService;
+
+    private Role userRole;
+
+    @BeforeEach
+    void setUp() {
+        userRole = new Role();
+        userRole.setName(ERole.ROLE_USER);
+    }
+
+    @Test
+    void shouldResolveValidRoles() {
+
+        Role adminRole = new Role();
+        adminRole.setName(ERole.ROLE_ADMIN);
+
+        when(roleRepository.findByName(ERole.ROLE_ADMIN))
+                .thenReturn(Optional.of(adminRole));
+
+        Set<Role> result = roleService.resolveRoles(List.of("ROLE_ADMIN"));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(adminRole));
+
+        verify(roleRepository).findByName(ERole.ROLE_ADMIN);
+    }
+
+    @Test
+    void shouldReturnDefaultRoleWhenNull() {
+
+        when(roleRepository.findByName(ERole.ROLE_USER))
+                .thenReturn(Optional.of(userRole));
+
+        Set<Role> result = roleService.resolveRoles(null);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(userRole));
+
+        verify(roleRepository).findByName(ERole.ROLE_USER);
+    }
+
+    @Test
+    void shouldReturnDefaultRoleWhenEmpty() {
+
+        when(roleRepository.findByName(ERole.ROLE_USER))
+                .thenReturn(Optional.of(userRole));
+
+        Set<Role> result = roleService.resolveRoles(List.of());
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(userRole));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidRole() {
+
+        List<String> roles = List.of("INVALID_ROLE");
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> roleService.resolveRoles(roles));
+
+        verify(roleRepository, never()).findByName(any());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenRoleNotFoundInDatabase() {
+
+        when(roleRepository.findByName(ERole.ROLE_ADMIN))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> roleService.resolveRoles(List.of("ROLE_ADMIN")));
+
+        verify(roleRepository).findByName(ERole.ROLE_ADMIN);
+    }
+
+}


### PR DESCRIPTION
### Summary
This PR centralizes role resolution logic by introducing a dedicated RoleService.

### Changes
- Created RoleService with resolveRoles method
- Replaced duplicated role logic in:
  - UserService
  - DTOConverter
- Removed switch-case structures for role handling
- Replaced RuntimeException with ResourceNotFoundException
- Added default ROLE_USER fallback for null or empty role lists

### Tests
- Added unit tests for RoleService covering:
  - Valid roles
  - Null and empty roles (default behavior)
  - Invalid roles
  - Roles not found in database

### Benefits
- Eliminates duplicated logic
- Improves maintainability
- Centralizes role-related behavior
- Enhances testability


Closes issue #72 