### PR TITLE
Add integration tests for repositories using H2 in-memory database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.2.224</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/io/github/codexrm/server/model/Reference.java
+++ b/src/main/java/io/github/codexrm/server/model/Reference.java
@@ -15,10 +15,10 @@ public class Reference {
     private String title;
 
 
-    @Column(name = "year")
+    @Column(name = "ref_year")
     private String year;
 
-    @Column(name = "month")
+    @Column(name = "ref_month")
     private String month;
 
     @Column(name = "note")

--- a/src/main/java/io/github/codexrm/server/repository/ReferenceRepository.java
+++ b/src/main/java/io/github/codexrm/server/repository/ReferenceRepository.java
@@ -11,10 +11,18 @@ import org.springframework.stereotype.Repository;
 public interface ReferenceRepository extends JpaRepository<Reference, Integer> {
 
         Page<Reference> findByUser(User user, Pageable pageable);
+
         Page<Reference> findByUserAndYearContaining(User user, String year, Pageable pageable);
+
         Page<Reference> findByUserAndTitleContaining(User user, String title, Pageable pageable);
+
+        Page<Reference> findByUserAndTitleContainingIgnoreCase(User user, String title, Pageable pageable);
+
         Page<Reference> findByYearContaining(String year, Pageable pageable);
+
         Page<Reference> findByTitleContaining(String title, Pageable pageable);
+
         Page<Reference> findByUserAndYearContainingAndTitleContaining(User user, String year, String title, Pageable pageable);
+
         Page<Reference> findByYearContainingAndTitleContaining(String year, String title, Pageable pageable);
 }

--- a/src/main/java/io/github/codexrm/server/repository/UserRepository.java
+++ b/src/main/java/io/github/codexrm/server/repository/UserRepository.java
@@ -12,7 +12,12 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByUsername(String username);
+
     Boolean existsByUsername(String username);
+
     Boolean existsByEmail(String email);
+
     Page<User> findByUsernameContaining(String username, Pageable pageable);
+
+    Page<User> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -12,3 +12,4 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 codexrm.app.jwtSecret=test-secret
 codexrm.app.jwtExpirationMs=3600000
 codexrm.app.jwtRefreshExpirationMs=864000000
+

--- a/src/test/java/io/github/codexrm/server/component/FieldValidationsTest.java
+++ b/src/test/java/io/github/codexrm/server/component/FieldValidationsTest.java
@@ -1,4 +1,4 @@
-package component;
+package io.github.codexrm.server.component;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/github/codexrm/server/component/repository/ReferenceRepositoryTest.java
+++ b/src/test/java/io/github/codexrm/server/component/repository/ReferenceRepositoryTest.java
@@ -1,0 +1,192 @@
+package io.github.codexrm.server.component.repository;
+
+import io.github.codexrm.server.model.Reference;
+import io.github.codexrm.server.model.User;
+import io.github.codexrm.server.repository.ReferenceRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class ReferenceRepositoryTest {
+
+    @Autowired
+    private ReferenceRepository referenceRepository;
+
+    @Autowired
+    private org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager entityManager;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setUsername("john");
+        user.setEmail("john@test.com");
+        user.setPassword("123");
+        user.setName("John");
+        user.setLastName("Doe");
+        user.setEnabled(true);
+
+        entityManager.persist(user);
+        entityManager.flush();
+    }
+
+    @Test
+    void shouldFindByUser() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Test title");
+        ref.setYear("2024");
+
+        entityManager.persist(ref);
+
+        Page<Reference> result = referenceRepository.findByUser(user, PageRequest.of(0, 10));
+
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void shouldFilterByTitle() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Spring Boot Guide");
+        ref.setYear("2024");
+
+        entityManager.persist(ref);
+
+        Page<Reference> result = referenceRepository
+                .findByUserAndTitleContaining(user, "Spring", PageRequest.of(0, 10));
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterByYear() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Any");
+        ref.setYear("2023");
+
+        entityManager.persist(ref);
+
+        Page<Reference> result = referenceRepository
+                .findByUserAndYearContaining(user, "2023", PageRequest.of(0, 10));
+
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    void shouldFilterByYearAndTitle() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Java");
+        ref.setYear("2022");
+
+        entityManager.persist(ref);
+
+        Page<Reference> result = referenceRepository
+                .findByUserAndYearContainingAndTitleContaining(
+                        user, "2022", "Java", PageRequest.of(0, 10)
+                );
+
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void shouldReturnEmptyPage() {
+        Page<Reference> result = referenceRepository
+                .findByUser(user, PageRequest.of(0, 10));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldPaginateReferences() {
+        for (int i = 0; i < 15; i++) {
+            Reference ref = new Reference();
+            ref.setUser(user);
+            ref.setTitle("Ref " + i);
+            ref.setYear("2024");
+            entityManager.persist(ref);
+        }
+
+        entityManager.flush();
+
+        Page<Reference> page1 = referenceRepository.findByUser(user, PageRequest.of(0, 10));
+        Page<Reference> page2 = referenceRepository.findByUser(user, PageRequest.of(1, 10));
+
+        assertEquals(10, page1.getContent().size());
+        assertEquals(5, page2.getContent().size());
+    }
+
+    @Test
+    void shouldNotReturnReferencesFromOtherUsers() {
+        User otherUser = new User();
+        otherUser.setUsername("other");
+        otherUser.setEmail("other@test.com");
+        otherUser.setPassword("123");
+        otherUser.setName("Other");
+        otherUser.setLastName("User");
+        otherUser.setEnabled(true);
+
+        entityManager.persist(otherUser);
+
+        Reference ref = new Reference();
+        ref.setUser(otherUser);
+        ref.setTitle("Other ref");
+        ref.setYear("2024");
+
+        entityManager.persist(ref);
+        entityManager.flush();
+
+        Page<Reference> result = referenceRepository.findByUser(user, PageRequest.of(0, 10));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenTitleDoesNotMatch() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Java");
+        ref.setYear("2024");
+
+        entityManager.persist(ref);
+        entityManager.flush();
+
+        Page<Reference> result = referenceRepository
+                .findByUserAndTitleContaining(user, "Python", PageRequest.of(0, 10));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldFilterIgnoringCase() {
+        Reference ref = new Reference();
+        ref.setUser(user);
+        ref.setTitle("Spring Boot");
+        ref.setYear("2024");
+
+        entityManager.persist(ref);
+        entityManager.flush();
+
+        Page<Reference> result = referenceRepository
+                .findByUserAndTitleContainingIgnoreCase(user, "spring", PageRequest.of(0, 10));
+
+        assertFalse(result.isEmpty());
+    }
+}

--- a/src/test/java/io/github/codexrm/server/component/repository/UserRepositoryTest.java
+++ b/src/test/java/io/github/codexrm/server/component/repository/UserRepositoryTest.java
@@ -1,0 +1,143 @@
+package io.github.codexrm.server.component.repository;
+
+import io.github.codexrm.server.model.User;
+import io.github.codexrm.server.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User createUser(String username, String email) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("123");
+        user.setEmail(email);
+        user.setName("Test");
+        user.setLastName("User");
+        user.setEnabled(true);
+        return user;
+    }
+
+    @Test
+    void shouldSaveAndFindUser() {
+        User user = createUser("testuser", "test@test.com");
+
+        User saved = userRepository.save(user);
+
+        Optional<User> result = userRepository.findById(saved.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals("testuser", result.get().getUsername());
+    }
+
+    @Test
+    void shouldFindByUsername() {
+        User user = createUser("maria", "maria@test.com");
+        userRepository.save(user);
+
+        Optional<User> result = userRepository.findByUsername("maria");
+
+        assertTrue(result.isPresent());
+        assertEquals("maria", result.get().getUsername());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenUsernameNotFound() {
+        Optional<User> result = userRepository.findByUsername("no-existe");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldCheckIfUsernameExists() {
+        userRepository.save(createUser("pedro", "pedro@test.com"));
+
+        Boolean exists = userRepository.existsByUsername("pedro");
+
+        assertTrue(exists);
+    }
+
+    @Test
+    void shouldReturnFalseIfUsernameDoesNotExist() {
+        Boolean exists = userRepository.existsByUsername("ghost");
+
+        assertFalse(exists);
+    }
+
+    @Test
+    void shouldCheckIfEmailExists() {
+        userRepository.save(createUser("ana", "ana@test.com"));
+
+        Boolean exists = userRepository.existsByEmail("ana@test.com");
+
+        assertTrue(exists);
+    }
+
+    @Test
+    void shouldReturnFalseIfEmailDoesNotExist() {
+        Boolean exists = userRepository.existsByEmail("no@test.com");
+
+        assertFalse(exists);
+    }
+
+    @Test
+    void shouldFindUsersByUsernameContaining() {
+        userRepository.save(createUser("juan123", "juan@test.com"));
+        userRepository.save(createUser("juan456", "juan2@test.com"));
+        userRepository.save(createUser("pedro", "pedro@test.com"));
+
+        Page<User> result = userRepository.findByUsernameContaining("juan", PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements());
+    }
+
+    @Test
+    void shouldReturnPagedUsers() {
+        userRepository.save(createUser("user1", "u1@test.com"));
+        userRepository.save(createUser("user2", "u2@test.com"));
+        userRepository.save(createUser("user3", "u3@test.com"));
+
+        Page<User> page = userRepository.findAll(PageRequest.of(0, 2));
+
+        assertEquals(2, page.getContent().size());
+        assertEquals(3, page.getTotalElements());
+    }
+
+    @Test
+    void shouldReturnEmptyPageWhenNoMatch() {
+        userRepository.save(createUser("carlos", "c@test.com"));
+
+        Page<User> result = userRepository.findByUsernameContaining("zzz", PageRequest.of(0, 10));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldFindUsersIgnoringCase() {
+        userRepository.save(createUser("Maria", "m@test.com"));
+
+        Page<User> result = userRepository
+                .findByUsernameContainingIgnoreCase("maria", PageRequest.of(0, 10));
+
+        assertFalse(result.isEmpty());
+    }
+}

--- a/src/test/java/io/github/codexrm/server/component/service/ReferenceServiceTest.java
+++ b/src/test/java/io/github/codexrm/server/component/service/ReferenceServiceTest.java
@@ -1,12 +1,12 @@
-package service;
+package io.github.codexrm.server.component.service;
 
+import io.github.codexrm.server.exception.DuplicateResourceException;
 import io.github.codexrm.server.exception.ResourceNotFoundException;
 import io.github.codexrm.server.model.Reference;
 import io.github.codexrm.server.model.User;
 import io.github.codexrm.server.repository.ReferenceRepository;
 import io.github.codexrm.server.service.ReferenceService;
-import jakarta.persistence.EntityExistsException;
-import jakarta.persistence.EntityNotFoundException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -59,7 +59,7 @@ class ReferenceServiceTest {
     void shouldThrowException_whenReferenceNotFound() {
         when(referenceRepository.findById(1)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> referenceService.get(1));
+        assertThrows(ResourceNotFoundException.class, () -> referenceService.get(1));
     }
 
     // =========================
@@ -147,7 +147,7 @@ class ReferenceServiceTest {
 
         when(referenceRepository.existsById(1)).thenReturn(true);
 
-        assertThrows(EntityExistsException.class, () -> referenceService.add(ref));
+        assertThrows(DuplicateResourceException.class, () -> referenceService.add(ref));
     }
 
     // =========================
@@ -160,6 +160,7 @@ class ReferenceServiceTest {
         ref.setId(1);
 
         when(referenceRepository.existsById(1)).thenReturn(true);
+        when(referenceRepository.findById(1)).thenReturn(Optional.of(ref));
         when(referenceRepository.save(ref)).thenReturn(ref);
 
         Reference result = referenceService.update(ref);
@@ -174,7 +175,7 @@ class ReferenceServiceTest {
 
         when(referenceRepository.existsById(1)).thenReturn(false);
 
-        assertThrows(EntityNotFoundException.class, () -> referenceService.update(ref));
+        assertThrows(ResourceNotFoundException.class, () -> referenceService.update(ref));
     }
 
     // =========================
@@ -183,11 +184,15 @@ class ReferenceServiceTest {
 
     @Test
     void shouldDeleteReference_whenExists() {
+        Reference ref = new Reference();
+        ref.setId(1);
+
         when(referenceRepository.existsById(1)).thenReturn(true);
+        when(referenceRepository.findById(1)).thenReturn(Optional.of(ref));
 
         referenceService.delete(1);
 
-        verify(referenceRepository).deleteById(1);
+        verify(referenceRepository).delete(ref);
     }
 
     @Test

--- a/src/test/java/io/github/codexrm/server/component/service/RoleServiceTest.java
+++ b/src/test/java/io/github/codexrm/server/component/service/RoleServiceTest.java
@@ -1,4 +1,4 @@
-package service;
+package io.github.codexrm.server.component.service;
 
 import io.github.codexrm.server.enums.ERole;
 import io.github.codexrm.server.exception.ResourceNotFoundException;

--- a/src/test/java/io/github/codexrm/server/component/service/UserServiceTest.java
+++ b/src/test/java/io/github/codexrm/server/component/service/UserServiceTest.java
@@ -1,9 +1,11 @@
-package service;
+package io.github.codexrm.server.component.service;
 
 import io.github.codexrm.server.model.User;
 import io.github.codexrm.server.repository.RoleRepository;
 import io.github.codexrm.server.repository.UserRepository;
 import io.github.codexrm.server.service.UserService;
+import io.github.codexrm.server.exception.ResourceNotFoundException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
@@ -11,8 +13,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.springframework.data.domain.*;
-
-import jakarta.persistence.EntityNotFoundException;
 
 import java.util.Optional;
 
@@ -56,7 +56,7 @@ class UserServiceTest {
     void shouldThrowException_whenUserNotExists() {
         when(userRepository.findById(1)).thenReturn(Optional.empty());
 
-        assertThrows(EntityNotFoundException.class, () -> userService.get(1));
+        assertThrows(ResourceNotFoundException.class, () -> userService.get(1));
     }
 
     // =========================
@@ -114,6 +114,7 @@ class UserServiceTest {
         user.setId(1);
 
         when(userRepository.existsById(1)).thenReturn(true);
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
         when(userRepository.save(user)).thenReturn(user);
 
         User result = userService.update(user);
@@ -128,7 +129,7 @@ class UserServiceTest {
 
         when(userRepository.existsById(1)).thenReturn(false);
 
-        assertThrows(EntityNotFoundException.class, () -> userService.update(user));
+        assertThrows(ResourceNotFoundException.class, () -> userService.update(user));
     }
 
     // =========================
@@ -137,18 +138,22 @@ class UserServiceTest {
 
     @Test
     void shouldDeleteUser_whenExists() {
+        User user = new User();
+        user.setId(1);
+
         when(userRepository.existsById(1)).thenReturn(true);
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
 
         userService.delete(1);
 
-        verify(userRepository).deleteById(1);
+        verify(userRepository).delete(user);
     }
 
     @Test
     void shouldThrowException_whenDeletingNonExistingUser() {
         when(userRepository.existsById(1)).thenReturn(false);
 
-        assertThrows(EntityNotFoundException.class, () -> userService.delete(1));
+        assertThrows(ResourceNotFoundException.class, () -> userService.delete(1));
     }
 
     // =========================

--- a/src/test/resources/application-test-h2.yml
+++ b/src/test/resources/application-test-h2.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+  h2:
+    console:
+      enabled: true
+
+  flyway:
+    enabled: false

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false


### PR DESCRIPTION
This PR adds integration tests for repository layer using @DataJpaTest and H2 in-memory database.

## Changes
- Added H2 dependency (test scope)
- Created test profile (application-test-h2.yml)
- Configured H2 in PostgreSQL compatibility mode
- Implemented tests for:
  - UserRepository
    - findByUsername
    - existsByUsername / existsByEmail
    - pagination and filtering
  - ReferenceRepository
    - find by user
    - filtering by title and year
    - combined filters
    - empty results
    - pagination

## Notes
H2 is used for fast feedback during testing. Some behaviors (e.g. case sensitivity or reserved keywords)
may differ slightly from PostgreSQL.

closes #85