### PR TITLE
docs: add architecture overview and consolidate project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ src/main/java/io/github/codexrm/server
 
 ---
 
+## Architecture Overview
+
+CodexRM follows a layered architecture designed to separate API exposure, business rules, persistence, and infrastructure concerns.
+
+Main architectural goals:
+
+- maintainability
+- clear separation of responsibilities
+- scalability
+- testability
+- framework isolation
+
+Key architectural decisions:
+
+- DTO-based API layer
+- JWT authentication with Spring Security
+- DTOConverter components for explicit DTO mapping
+- Flyway-managed database migrations
+- OpenAPI-first API documentation
+
+---
+
 ## Running the Project
 
 ### Prerequisites

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,3 +224,103 @@ The current architecture was designed to:
 - Support future scalability
 - Improve code readability
 - Separate technical concerns from business logic
+
+---
+
+## DTO Conversion Strategy
+
+The project uses explicit DTO conversion to separate API contracts from domain entities.
+
+DTO conversion responsibilities are centralized in reusable converter components located in the `component` package.
+
+### Goals of DTO Conversion
+
+- isolate domain models from external API contracts
+- avoid exposing internal entities directly
+- improve maintainability
+- support request/response specialization
+- simplify validation and serialization
+
+### Mapping Approach
+
+The project favors explicit mapping strategies instead of relying entirely on automatic object mapping libraries.
+
+Reasons include:
+
+- better control over polymorphic scenarios
+- predictable mapping behavior
+- easier debugging
+- reduced hidden conversion logic
+
+Code reading notes about ModelMapper limitations and inheritance behavior is documented in:
+
+```text
+docs/code-reading/modelmapper.md
+```
+---
+
+## OpenAPI Documentation
+
+The project uses `springdoc-openapi` to automatically generate OpenAPI 3 documentation and Swagger UI integration.
+
+### OpenAPI Goals
+
+- improve API discoverability
+- simplify frontend/backend integration
+- standardize endpoint documentation
+- expose request/response schemas
+- document authentication requirements
+
+### Swagger UI
+
+Swagger UI is available at:
+
+```text
+/swagger-ui.html
+```
+
+### OpenAPI JSON
+
+The generated OpenAPI specification is available at:
+
+```text
+/v3/api-docs
+```
+
+The project includes:
+
+- endpoint documentation with `@Operation`
+- request/response examples using `@Schema`
+- JWT authentication documentation with `@SecurityScheme`
+- standardized error response schemas
+
+Additional documentation and code reading notes are available in:
+
+```text
+docs/code-reading/springdoc-openapi.md
+```
+
+---
+
+## Design Principles
+
+The architecture follows a set of design principles intended to keep the codebase maintainable and scalable.
+
+### Core Principles
+
+- clear separation of concerns
+- explicit boundaries between layers
+- framework isolation from business rules
+- reusable infrastructure components
+- API-first documentation practices
+- predictable DTO conversion behavior
+
+### Long-Term Goals
+
+- simplify onboarding for new contributors
+- support future modularization
+- improve testability
+- maintain consistent API documentation
+- reduce architectural coupling
+
+---

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -220,3 +220,92 @@ Jackson polymorphic deserialization is used to resolve DTO subtypes through the 
 - More complex JSON serialization and deserialization
 - Requires explicit subtype configuration
 - Error handling becomes more complex when subtype information is missing
+
+---
+
+## ADR-007: Favor Explicit DTO Conversion over Automatic Mapping
+
+### Status
+Accepted
+
+### Context
+
+The project uses multiple DTO types and inheritance-based request/response structures.
+
+Automatic mapping libraries such as ModelMapper can simplify DTO conversion, but inheritance-heavy and polymorphic scenarios may introduce hidden mapping behavior and reduce predictability.
+
+A code reading analysis was conducted to evaluate ModelMapper inheritance support and runtime polymorphism limitations.
+
+### Decision
+
+Favor explicit DTO conversion using dedicated converter components instead of relying entirely on automatic object mapping libraries.
+
+DTO conversion responsibilities are centralized in reusable components located in the `component` package.
+
+### Consequences
+
+#### Positive
+
+- Better control over polymorphic DTO conversion
+- Predictable and explicit mapping behavior
+- Easier debugging and maintenance
+- Reduced hidden conversion logic
+- Clear separation between API and domain layers
+
+#### Negative
+
+- More verbose mapping code
+- Additional maintenance effort for DTO converters
+- Slower initial implementation compared to automatic mapping libraries
+
+### Related Documentation
+
+```text
+docs/code-reading/modelmapper.md
+```
+
+---
+
+## ADR-008: Standardize OpenAPI Documentation with `springdoc-openapi`
+
+### Status
+Accepted
+
+### Context
+
+The project exposes a REST API consumed by multiple clients and requires consistent API documentation for development, testing, and integration purposes.
+
+Manual API documentation approaches are difficult to maintain as the API evolves.
+
+### Decision
+
+Use `springdoc-openapi` for automatic OpenAPI 3 specification generation and Swagger UI integration.
+
+Endpoints should include explicit documentation annotations such as:
+
+- `@Operation`
+- `@ApiResponse`
+- `@Schema`
+- `@SecurityScheme`
+
+### Consequences
+
+#### Positive
+
+- Standardized API documentation
+- Improved developer onboarding
+- Easier frontend/backend integration
+- Automatic OpenAPI specification generation
+- Interactive Swagger UI support
+
+#### Negative
+
+- Requires maintaining annotation consistency
+- Additional documentation effort during development
+- Complex DTO hierarchies may require manual schema adjustments
+
+### Related Documentation
+
+```text
+docs/code-reading/springdoc-openapi.md
+```


### PR DESCRIPTION
## Summary

Consolidated and refined project documentation across architecture, OpenAPI, and design decision records.

## Included

- architecture overview improvements
- DTO conversion strategy documentation
- OpenAPI documentation notes
- decision log updates
- code reading notes consolidation
- Swagger/OpenAPI audit integration

## Verified

- documentation structure is organized and consistent
- Swagger/OpenAPI documentation remains aligned with the codebase
- architectural decisions are documented and traceable

closes #105