### PR TITLE
test(cleanup): remove fragile and low-value integration tests (#117)

### DIFF
--- a/src/test/java/io/github/codexrm/server/api/controller/ReferenceControllerTest.java
+++ b/src/test/java/io/github/codexrm/server/api/controller/ReferenceControllerTest.java
@@ -213,7 +213,7 @@ class ReferenceControllerTest {
 
         when(userService.get(1)).thenReturn(user);
         when(dtoConverter.toReferenceList(any(), any())).thenReturn(List.of());
-        doNothing().when(referenceService).sync(user, any(), any(), any());
+        doNothing().when(referenceService).sync(eq(user), any(), any(), any());
         when(referenceService.getAll(any(), any(), any(), anyInt(), anyInt(), any()))
                 .thenReturn(page);
 
@@ -242,7 +242,7 @@ class ReferenceControllerTest {
 
         when(userService.get(1)).thenReturn(user);
         when(dtoConverter.toReferenceList(any(), any())).thenReturn(List.of());
-        doNothing().when(referenceService).sync(user, any(), any(), any());
+        doNothing().when(referenceService).sync(eq(user), any(), any(), any());
         when(referenceService.getAll(any(), any(), any(), anyInt(), anyInt(), any()))
                 .thenReturn(Page.empty());
 

--- a/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/AuthIntegrationTest.java
+++ b/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/AuthIntegrationTest.java
@@ -12,7 +12,6 @@ import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AuthIntegrationTest extends BaseIntegrationTest{
@@ -22,6 +21,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest{
 
     @LocalServerPort
     private int port;
+
 
     private String url(String path) {
         return "http://localhost:" + port + path;
@@ -84,7 +84,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest{
                         String.class
                 );
 
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     }
 
     @Test

--- a/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceAuthorizationIntegrationTest.java
+++ b/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceAuthorizationIntegrationTest.java
@@ -101,7 +101,7 @@ public class ReferenceAuthorizationIntegrationTest extends BaseIntegrationTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
-        return response.getBody(); // assuming it returns JSON with id or similar
+        return response.getBody();
     }
 
     // Test

--- a/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceFlowIntegrationTest.java
+++ b/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceFlowIntegrationTest.java
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.codexrm.server.api.dto.request.LoginRequest;
 import io.github.codexrm.server.api.dto.request.SignupRequest;
-import io.github.codexrm.server.infrastructure.persistence.repository.ReferenceRepository;
-import io.github.codexrm.server.infrastructure.persistence.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -33,12 +30,6 @@ public class ReferenceFlowIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private ReferenceRepository referenceRepository;
 
     @Test
     void shouldCompleteFullReferenceFlow() throws Exception {
@@ -72,7 +63,6 @@ public class ReferenceFlowIntegrationTest extends BaseIntegrationTest {
                         String.class
                 );
 
-        System.out.println(response.getBody());
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     }
 

--- a/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceSynchronizationIntegrationTest.java
+++ b/src/test/java/io/github/codexrm/server/infrastructure/persistence/integration/ReferenceSynchronizationIntegrationTest.java
@@ -13,19 +13,15 @@ import io.github.codexrm.server.infrastructure.persistence.repository.UserReposi
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+
 class ReferenceSynchronizationIntegrationTest extends BaseIntegrationTest  {
 
     @Autowired
@@ -177,10 +173,9 @@ class ReferenceSynchronizationIntegrationTest extends BaseIntegrationTest  {
                 .findById(saved.getId())
                 .orElseThrow();
 
-        assertEquals("New Title", result.getTitle());
-        assertEquals("Silva,Joao",
-                ((ArticleReference) result).getAuthor());
-        assertEquals("2025", result.getYear());
+        assertThat(result.getTitle()).isEqualTo("New Title");
+        assertThat(((ArticleReference) result).getAuthor()).isEqualTo("Silva,Joao");
+        assertThat(result.getYear()).isEqualTo("2025");
     }
 
     @Test
@@ -214,13 +209,5 @@ class ReferenceSynchronizationIntegrationTest extends BaseIntegrationTest  {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isNoContent());
-    }
-
-    @Test
-    void shouldExposeOpenApiDocs() throws Exception {
-
-        mockMvc.perform(get("/v3/api-docs"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
## Objective

Reduce false positives and improve test suite stability.

## Changes

- removed duplicated OpenAPI integration coverage
- standardized assertions across integration tests
- fixed Mockito matcher usage in controller tests
- removed unused test dependencies and debug output
- reviewed integration tests for execution-order dependencies
- verified isolated test data setup and predictable execution

## Result

- no duplicated OpenAPI coverage
- no invalid Mockito matcher usage
- improved test consistency and maintainability
- full test suite passes successfully

## Validation

- Tests run: 146
- Failures: 0
- Errors: 0
- Skipped: 0

closes #117