### PR TITLE
refactor(errors): standardize API error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,34 @@ Services started:
 
 ---
 
+## Error Handling
+
+The API returns a consistent JSON error structure for all error responses:
+
+```json
+{
+  "timestamp": "2026-03-15T10:30:00Z",
+  "status": 404,
+  "error": "Not Found",
+  "message": "User not found with id: 1",
+  "path": "/api/users/1"
+}
+```
+
+### Status codes
+
+| Exception / Condition | HTTP Status |
+|---|---|
+| `ResourceNotFoundException`, JPA `EntityNotFoundException` | 404 Not Found |
+| `DuplicateResourceException` | 409 Conflict |
+| `BadRequestException`, `IllegalArgumentException`, malformed JSON body, invalid parameter type | 400 Bad Request |
+| `@Valid` validation errors (all field errors returned, semicolon-separated) | 400 Bad Request |
+| Missing or invalid JWT (unauthenticated request) | 401 Unauthorized |
+| `InvalidOperationException`, `TokenRefreshException`, Spring Security `AccessDeniedException` | 403 Forbidden |
+| Any unhandled exception | 500 Internal Server Error (generic message; details are logged server-side, never returned to the client) |
+
+---
+
 ## Running Tests
 
 Run all tests:

--- a/src/main/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandler.java
@@ -16,6 +16,8 @@ import java.time.Instant;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     // 404 - Resource not found (custom)
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleResourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
@@ -37,11 +39,18 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(ex, request, HttpStatus.CONFLICT);
     }
 
-    // 400 - Invalid operation (custom)
+    // 403 - Invalid operation (custom)
     @ExceptionHandler(InvalidOperationException.class)
     public ResponseEntity<ErrorResponse> handleInvalidOperation(InvalidOperationException ex, HttpServletRequest request) {
 
         return buildErrorResponse(ex, request, HttpStatus.FORBIDDEN);
+    }
+
+    // 400 - Bad request (custom)
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex, HttpServletRequest request) {
+
+        return buildErrorResponse(ex, request, HttpStatus.BAD_REQUEST);
     }
 
     //  400 - Illegal arguments
@@ -73,8 +82,11 @@ public class GlobalExceptionHandler {
                 .getFieldErrors()
                 .stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .findFirst()
-                .orElse("Validation error");
+                .collect(java.util.stream.Collectors.joining("; "));
+
+        if (message.isBlank()) {
+            message = "Validation error";
+        }
 
         ErrorResponse error = new ErrorResponse(
                 Instant.now(),
@@ -87,11 +99,52 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
+    // 400 - Malformed JSON body
+    @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleMalformedJson(
+            org.springframework.http.converter.HttpMessageNotReadableException ex, HttpServletRequest request) {
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "Malformed JSON request body",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    // 400 - Wrong parameter type (e.g. ?page=abc)
+    @ExceptionHandler(org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(
+            org.springframework.web.method.annotation.MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+
+        String message = "Invalid value for parameter '" + ex.getName() + "'";
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                message,
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
     // 500 - fallback
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, HttpServletRequest request) {
 
-        return buildErrorResponse(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
+        logger.error("Unhandled exception at {}", request.getRequestURI(), ex);
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                "An unexpected error occurred",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     // 401 - Invalid credentials

--- a/src/main/java/io/github/codexrm/server/infrastructure/security/AccessDeniedHandlerImpl.java
+++ b/src/main/java/io/github/codexrm/server/infrastructure/security/AccessDeniedHandlerImpl.java
@@ -1,0 +1,43 @@
+package io.github.codexrm.server.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.codexrm.server.api.dto.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Component
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AccessDeniedHandlerImpl.class);
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        logger.warn("Access denied for {}: {}", request.getRequestURI(), accessDeniedException.getMessage());
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "You do not have permission to access this resource",
+                request.getRequestURI()
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/src/main/java/io/github/codexrm/server/infrastructure/security/WebSecurityConfig.java
+++ b/src/main/java/io/github/codexrm/server/infrastructure/security/WebSecurityConfig.java
@@ -10,12 +10,12 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import io.github.codexrm.server.infrastructure.security.jwt.AuthEntryPointJwt;
 
 @Configuration
 @EnableMethodSecurity
@@ -23,11 +23,13 @@ public class WebSecurityConfig {
 
   private final UserDetailsServiceImpl userDetailsService;
   private final AuthEntryPointJwt unauthorizedHandler;
+  private final AccessDeniedHandlerImpl accessDeniedHandler;
 
   public WebSecurityConfig(UserDetailsServiceImpl userDetailsService,
-                           AuthEntryPointJwt unauthorizedHandler) {
+                           AuthEntryPointJwt unauthorizedHandler, AccessDeniedHandlerImpl accessDeniedHandler) {
     this.userDetailsService = userDetailsService;
     this.unauthorizedHandler = unauthorizedHandler;
+    this.accessDeniedHandler = accessDeniedHandler;
   }
 
   // JWT Filter
@@ -72,8 +74,9 @@ public class WebSecurityConfig {
             .csrf(csrf -> csrf.disable())
 
             .exceptionHandling(exception ->
-                    exception.authenticationEntryPoint(unauthorizedHandler))
-
+                    exception
+                            .authenticationEntryPoint(unauthorizedHandler)
+                            .accessDeniedHandler(accessDeniedHandler))
             .sessionManagement(session ->
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 

--- a/src/main/java/io/github/codexrm/server/infrastructure/security/jwt/AuthEntryPointJwt.java
+++ b/src/main/java/io/github/codexrm/server/infrastructure/security/jwt/AuthEntryPointJwt.java
@@ -1,20 +1,24 @@
 package io.github.codexrm.server.infrastructure.security.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.codexrm.server.api.dto.response.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Instant;
 
 @Component
 public class AuthEntryPointJwt implements AuthenticationEntryPoint {
 
     private static final Logger logger = LoggerFactory.getLogger(AuthEntryPointJwt.class);
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Override
     public void commence(HttpServletRequest request,
@@ -22,14 +26,19 @@ public class AuthEntryPointJwt implements AuthenticationEntryPoint {
                          AuthenticationException authException)
             throws IOException {
 
+        logger.warn("Unauthorized access attempt to {}: {}", request.getRequestURI(), authException.getMessage());
+
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        response.getWriter().write("""
-            {
-              "error": "Unauthorized",
-              "message": "Bad credentials"
-            }
-        """);
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "Full authentication is required to access this resource",
+                request.getRequestURI()
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(error));
     }
 }

--- a/src/test/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandlerTest.java
@@ -68,6 +68,14 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void badRequestExceptionMapsTo400() {
+        ResponseEntity<ErrorResponse> response =
+                handler.handleBadRequest(new BadRequestException("Missing required fields for Reference"), request);
+
+        assertStatus(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     void tokenRefreshExceptionMapsTo403() {
         ResponseEntity<ErrorResponse> response =
                 handler.handleTokenRefreshException(
@@ -90,6 +98,28 @@ class GlobalExceptionHandlerTest {
                 handler.handleBadCredentials(new BadCredentialsException("bad credentials"), request);
 
         assertStatus(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void malformedJsonMapsTo400() {
+        org.springframework.http.converter.HttpMessageNotReadableException ex =
+                mock(org.springframework.http.converter.HttpMessageNotReadableException.class);
+
+        ResponseEntity<ErrorResponse> response = handler.handleMalformedJson(ex, request);
+
+        assertStatus(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void typeMismatchMapsTo400() {
+        org.springframework.web.method.annotation.MethodArgumentTypeMismatchException ex =
+                mock(org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class);
+        when(ex.getName()).thenReturn("page");
+
+        ResponseEntity<ErrorResponse> response = handler.handleTypeMismatch(ex, request);
+
+        assertStatus(response, HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).contains("page");
     }
 
     @Test


### PR DESCRIPTION
## Objective
Consolidate and standardize API error responses.

## Summary
Audited exception mapping, validation errors, auth errors, and
business rule violations across the API. Found a real bug (wrong
status code returned to clients) and several consistency gaps.

## Findings and fixes

### 🔴 `BadRequestException` had no handler → returned 500
Thrown 7 times in `ValidateReference.java` for missing required
reference fields, but with no `@ExceptionHandler` registered it fell
through to the generic 500 fallback. Any client sending an incomplete
`Reference` payload got a 500 instead of a 400.
**Fix:** added `handleBadRequest` mapping it to 400.

### 401 responses used a different JSON shape than the rest of the API
`AuthEntryPointJwt` built its response body by hand
(`{"error": ..., "message": ...}`), while every other error path uses
the shared `ErrorResponse` (`timestamp, status, error, message, path`).
**Fix:** rewritten to reuse `ErrorResponse`.

### No consistent 403 for filter-level authorization denials
`AccessDeniedException` thrown inside a controller/service (e.g. from
`@PreAuthorize`) was already caught by `GlobalExceptionHandler`, but
denials at the `authorizeHttpRequests` filter level had no custom
handler and fell back to Spring Security's default behavior.
**Fix:** added `AccessDeniedHandlerImpl`, wired into
`WebSecurityConfig`, returning the same `ErrorResponse` shape.

### Validation errors only reported the first invalid field
`handleValidationErrors` used `.findFirst()`, discarding every other
field error in the same request.
**Fix:** now joins all field errors into a single message.

### Malformed requests fell through to 500
No handlers existed for malformed JSON bodies
(`HttpMessageNotReadableException`) or wrongly-typed query/path
parameters (`MethodArgumentTypeMismatchException`) — both returned
500 instead of 400.
**Fix:** added dedicated handlers for both.

### Generic 500 fallback echoed raw exception messages to clients
Could leak internal details (e.g. DB connection errors) in production.
**Fix:** the raw exception is now logged server-side; the client
receives a fixed, generic message.

### Misleading comment
`InvalidOperationException`'s handler comment said "400" while the
actual status was 403. Comment corrected.

## Acceptance criteria
- [x] Error responses follow a consistent structure
- [x] HTTP status codes are correct
- [x] Existing tests continue to pass
- [x] Error handling behavior is documented

## Verification
`mvn verify`: **134 unit tests + 21 integration tests**, all passing,
including 3 new cases in `GlobalExceptionHandlerTest` covering the
newly added handlers.

## Notes
No changes to business logic — this PR only touches how errors are
caught, formatted, and reported.


closes #135