### PR TITLE
fix(import-export): harden file processing and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ The API returns a consistent JSON error structure for all error responses:
 
 ---
 
+## Import / Export
+
+### Import (`POST /api/references/import`)
+- Accepted formats: `RIS`, `BIBTEX` (case-insensitive).
+- Accepted file extensions: `.ris`, `.bib`, `.bibtex`.
+- Maximum file size: 10MB.
+- Files with an unsupported format or extension are rejected with 400.
+- Malformed file content (unparseable RIS/BibTeX) is rejected with 400.
+
+### Export (`POST /api/references/export`)
+- Accepted formats: `RIS`, `BIBTEX` (case-insensitive).
+- The `fileName` parameter is sanitized server-side (path components are
+  stripped) before being used to write the export file.
+
+---
+
 ## Running Tests
 
 Run all tests:

--- a/src/main/java/io/github/codexrm/server/api/controller/ReferenceController.java
+++ b/src/main/java/io/github/codexrm/server/api/controller/ReferenceController.java
@@ -50,6 +50,10 @@ public class ReferenceController {
 
     private static final String UPLOADED_FOLDER = System.getProperty("java.io.tmpdir") + "/tempUpload";
 
+    private static final List<String> ALLOWED_IMPORT_EXTENSIONS = List.of("ris", "bib", "bibtex");
+    private static final List<String> ALLOWED_IMPORT_FORMATS = List.of("RIS", "BIBTEX");
+    private static final List<String> ALLOWED_EXPORT_FORMATS = List.of("RIS", "BIBTEX");
+
     private final ReferenceService referenceService;
     private final UserService userService;
     private final DTOConverter dtoConverter;
@@ -247,21 +251,34 @@ public class ReferenceController {
 
         if (uploadFile.isEmpty()) throw new IllegalArgumentException("You must select a file!");
 
-
-        saveUploadedFile(uploadFile);
-        User user = getAuthenticatedUser();
-        File file = new File(UPLOADED_FOLDER, uploadFile.getOriginalFilename());
-
-        ArrayList<Reference> list = referenceService.importReferences(file.getPath(), format);
-
-        for (Reference r : list) {
-            r.setUser(user);
-            referenceService.add(r);
+        if (format == null || !ALLOWED_IMPORT_FORMATS.contains(format.toUpperCase())) {
+            throw new IllegalArgumentException("Unsupported import format: " + format);
         }
 
-        file.delete();
+        String originalName = Optional.ofNullable(uploadFile.getOriginalFilename()).orElse("");
+        String extension = originalName.contains(".")
+                ? originalName.substring(originalName.lastIndexOf('.') + 1).toLowerCase()
+                : "";
 
-        return ResponseEntity.ok(new MessageResponse("Reference Imported!"));
+        if (!ALLOWED_IMPORT_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("Unsupported file extension: " + extension);
+        }
+
+        File file = saveUploadedFile(uploadFile);
+
+        try {
+            User user = getAuthenticatedUser();
+            ArrayList<Reference> list = referenceService.importReferences(file.getPath(), format);
+
+            for (Reference r : list) {
+                r.setUser(user);
+                referenceService.add(r);
+            }
+
+            return ResponseEntity.ok(new MessageResponse("Reference Imported!"));
+        } finally {
+            file.delete();
+        }
     }
 
     @Operation(summary = "Export references")
@@ -272,6 +289,14 @@ public class ReferenceController {
             @RequestParam (name = "format", defaultValue = "RIS") String format,
             @Valid @RequestBody ArrayList<Integer> idList) throws IOException {
 
+        if (format == null || !ALLOWED_EXPORT_FORMATS.contains(format.toUpperCase())) {
+            throw new IllegalArgumentException("Unsupported export format: " + format);
+        }
+
+        String safeFileName = Paths.get(
+                Optional.ofNullable(fileName).orElse("file.txt")
+        ).getFileName().toString();
+
         User user = getAuthenticatedUser();
         ArrayList<Integer> filteredIds = filterUserReferences(user.getId(), idList);
 
@@ -280,21 +305,24 @@ public class ReferenceController {
             references.add(referenceService.get(id));
         }
 
-        Path path = Paths.get(UPLOADED_FOLDER, fileName);
+        String uniqueName = UUID.randomUUID() + "_" + safeFileName;
+        Path path = Paths.get(UPLOADED_FOLDER, uniqueName);
         Files.createDirectories(path.getParent());
 
         File file = new File(path.toString());
-        referenceService.exportReferences(file, references, format);
 
-        ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(path));
+        try {
+            referenceService.exportReferences(file, references, format);
 
-        file.delete();
+            ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(path));
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
-                .contentLength(resource.contentLength())
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(resource);
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + safeFileName + "\"")
+                    .contentLength(resource.contentLength()).contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .body(resource);
+        } finally {
+            file.delete();
+        }
     }
 
     @Operation(summary = "Get references from all users")
@@ -318,13 +346,16 @@ public class ReferenceController {
     }
 
     //FILE HANDLING
-    private void saveUploadedFile(MultipartFile file) throws IOException {
+    private File saveUploadedFile(MultipartFile file) throws IOException {
         String fileName = Optional.ofNullable(file.getOriginalFilename()).orElse("upload.tmp");
 
         fileName = Paths.get(fileName).getFileName().toString();
+        String uniqueFileName = UUID.randomUUID() + "_" + fileName;
 
-        Path path = Paths.get(UPLOADED_FOLDER, fileName);
+        Path path = Paths.get(UPLOADED_FOLDER, uniqueFileName);
         Files.createDirectories(path.getParent());
         Files.write(path, file.getBytes());
+
+        return path.toFile();
     }
 }

--- a/src/main/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/codexrm/server/infrastructure/exception/GlobalExceptionHandler.java
@@ -131,6 +131,35 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
+    // 400 - Malformed RIS/BibTeX content
+    @ExceptionHandler({org.jbibtex.ParseException.class, org.jbibtex.TokenMgrException.class})
+    public ResponseEntity<ErrorResponse> handleParseException(Exception ex, HttpServletRequest request) {
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "The uploaded file could not be parsed. Please check the file format and content.",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    // 413 - File too large
+    @ExceptionHandler(org.springframework.web.multipart.MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
+            org.springframework.web.multipart.MaxUploadSizeExceededException ex, HttpServletRequest request) {
+
+        ErrorResponse error = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                HttpStatus.PAYLOAD_TOO_LARGE.getReasonPhrase(),
+                "The uploaded file exceeds the maximum allowed size (10MB).",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+
     // 500 - fallback
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, HttpServletRequest request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.profiles.active=dev
+
+# File upload limits
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB

--- a/src/test/java/io/github/codexrm/server/api/controller/ReferenceControllerTest.java
+++ b/src/test/java/io/github/codexrm/server/api/controller/ReferenceControllerTest.java
@@ -299,6 +299,44 @@ class ReferenceControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    // Debe fallar si el formato no está soportado (400)
+    @Test
+    void shouldFailImportWhenFormatIsUnsupported() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "uploadFile",
+                "test.ris",
+                "text/plain",
+                "content".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/references/import")
+                        .file(file)
+                        .param("format", "XML")
+                        .with(user(mockUser()))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    // Debe fallar si la extensión del archivo no está permitida (400)
+    @Test
+    void shouldFailImportWhenExtensionIsUnsupported() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "uploadFile",
+                "malicious.exe",
+                "application/octet-stream",
+                "content".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/references/import")
+                        .file(file)
+                        .param("format", "RIS")
+                        .with(user(mockUser()))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
     // EXPORT
     // Debe exportar referencias correctamente (200)
     @Test
@@ -329,6 +367,36 @@ class ReferenceControllerTest {
                 .andExpect(status().isOk());
     }
 
+    // Debe sanitizar el fileName y evitar path traversal (200, sin escribir fuera de la carpeta temporal)
+    @Test
+    void shouldSanitizeFileNameOnExport() throws Exception {
+
+        User user = mockUserEntity();
+        Reference ref = new Reference();
+
+        when(userService.get(1)).thenReturn(user);
+        when(referenceService.get(anyInt())).thenReturn(ref);
+
+        doAnswer(invocation -> {
+            File file = invocation.getArgument(0);
+            Files.createDirectories(file.toPath().getParent());
+            Files.write(file.toPath(), "test".getBytes());
+            return null;
+        }).when(referenceService).exportReferences(any(), any(), any());
+
+        List<Integer> ids = List.of(1);
+
+        mockMvc.perform(post("/api/references/export")
+                        .with(user(mockUser()))
+                        .with(csrf())
+                        .param("fileName", "../../../../etc/passwd")
+                        .param("format", "RIS")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(ids)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("passwd")))
+                .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString(".."))));
+    }
     //ALL USERS
     //  Debe permitir acceso a MANAGER (200)
     @Test


### PR DESCRIPTION
## Objective
Review import/export functionality and address remaining security or
validation concerns.

## Summary
Final issue of this security-hardening milestone. Audited file upload
validation, RIS/BibTeX import processing, and export behavior.
Found one critical vulnerability and several defensive gaps.

## Findings and fixes

### 🔴 Critical: path traversal in the export endpoint
`POST /api/references/export` took the client-supplied `fileName`
query parameter and used it directly to build the file path
(`Paths.get(UPLOADED_FOLDER, fileName)`), with no sanitization —
unlike the import endpoint, which already stripped path components.
A request with e.g. `fileName=../../../../some/path` could write the
exported file outside the intended temp directory.
**Fix:** `fileName` is now sanitized the same way as import, via
`Paths.get(fileName).getFileName()`, before being used. Covered by a
new test asserting the traversal segments are stripped.

### No file extension / format validation on import
Any file type was accepted and blindly parsed according to the
client-supplied `format` parameter, with no cross-check between the
two, and no allowlist for either.
**Fix:** added an explicit allowlist for both `format`
(`RIS`/`BIBTEX`) and file extension (`.ris`, `.bib`, `.bibtex`).
Unsupported values are now rejected with 400.

### Invalid format silently became `null`
`EnumsConverter.getFormat()` swallowed invalid format strings and
returned `null` rather than surfacing an error, which then propagated
into the external EIManager library uncontrolled.
**Fix:** the new allowlist check happens before that code path is
reached.

### Malformed file content returned 500
`ParseException` / `TokenMgrException` from the RIS/BibTeX parser had
no dedicated handler and fell through to the generic 500 fallback.
**Fix:** added handlers mapping both to 400.

### No file size limit
Upload size relied on undocumented Spring Boot defaults, and
exceeding it (`MaxUploadSizeExceededException`) also had no handler
and returned 500.
**Fix:** explicit 10MB limit configured, with a dedicated handler
returning 413.

### Temp files not cleaned up on failure
`file.delete()` only ran on the success path for both import and
export; a failed request left the temp file on disk indefinitely.
**Fix:** wrapped in try/finally on both endpoints.

### Filename collisions between concurrent uploads
Temp files were saved using the original filename with no uniqueness
guarantee, risking collisions between concurrent requests.
**Fix:** temp files are now prefixed with a UUID.

## Acceptance criteria
- [x] Invalid files are rejected
- [x] Supported formats continue to work
- [x] Import/export tests pass
- [x] No known critical import/export defects remain open

## Verification
`mvn verify`: **134 unit tests + 21 integration tests**, all passing,
including 15 tests in `ReferenceControllerTest` (12 existing + 3 new
covering unsupported format, unsupported extension, and the path
traversal fix).

## Notes
This closes out the security-hardening milestone (#134, #136, #137).
No changes to reference business logic — only file handling,
validation, and error mapping around import/export.

closes #137