### PR TITLE
fix(config): use ddl-auto=validate in production instead of update

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,7 +5,7 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.jpa.generate-ddl=false
 


### PR DESCRIPTION
## Objective
Prevent Hibernate from auto-modifying the production schema outside
of Flyway's control.

## Problem
`application-prod.properties` had `spring.jpa.hibernate.ddl-auto=update`,
while `application-dev.properties` correctly used `validate`. With
`update` in production, Hibernate can automatically alter the schema
on every startup based on entity mappings — bypassing Flyway's
version-controlled migrations entirely. This risked:
- Schema drift between what Flyway's history table records and what
  actually exists in the database.
- Uncontrolled, undocumented DDL changes applied automatically at
  boot time in production.
- Flyway migrations silently becoming out of sync with reality.

## Fix
Changed `spring.jpa.hibernate.ddl-auto` from `update` to `validate`
in `application-prod.properties`, matching the dev profile's
(correct) configuration.

## Acceptance Criteria
- [x] `application-prod.properties` uses `ddl-auto=validate`
- [x] Application starts successfully in prod profile with `validate`
      (confirms schema/entity sync)
- [x] Existing tests continue to pass
- [x] No behavior change to dev/test profiles

## Verification
- `mvn verify`: full test suite passes.
- Real prod-profile startup via `docker compose up --build`: server
  starts cleanly (`Started ServerApplication in X seconds`), with no
  `Schema-validation` errors — confirming the entity mappings and the
  Flyway-managed schema (V1, V2) are fully in sync.

## Notes
This closes out the migrations review gap identified when checking
this week's success criteria against auth, migrations, and core
endpoints. No changes to dev or test profiles, and no migration files
were added or modified — only the prod DDL strategy.