### PR TITLE
docs: consolidate run, test and architecture notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,23 @@ Postman will automatically generate a collection with all endpoints.
 
 ---
 
+## Local Validation
+
+Before opening a PR, especially for changes touching API, security,
+or configuration:
+
+1. Levantar dependencias necesarias (`docker compose up db`, o el
+   stack completo con `docker compose up --build`).
+2. Ejecutar tests unitarios (`mvn test`).
+3. Ejecutar tests de integración críticos (`mvn verify`, o
+   `mvn test -Dtest="*IntegrationTest"` para correr solo integración).
+   Ver [docs/testing.md](docs/testing.md) para el detalle de qué
+   cubre la suite crítica.
+4. Verificar Swagger UI si el cambio toca API, seguridad o configuración
+   (`http://localhost:8081/swagger-ui.html`).
+
+---
+
 ## Useful Development Commands
 
 Build the project:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,3 +324,86 @@ The architecture follows a set of design principles intended to keep the codebas
 - reduce architectural coupling
 
 ---
+
+## Error Handling
+
+All API errors are returned with a consistent JSON structure via a
+global `@RestControllerAdvice` (`GlobalExceptionHandler`):
+
+```json
+{
+  "timestamp": "2026-03-15T10:30:00Z",
+  "status": 404,
+  "error": "Not Found",
+  "message": "User not found with id: 1",
+  "path": "/api/users/1"
+}
+```
+
+This applies regardless of where the error originates:
+
+- Exceptions thrown inside controllers/services are caught by
+  `GlobalExceptionHandler`.
+- Missing/invalid JWT (401) is handled by `AuthEntryPointJwt`.
+- Authorization denials at the security filter level (403) are
+  handled by `AccessDeniedHandlerImpl`.
+
+Both handlers build the same `ErrorResponse` shape as the global
+handler, so the response format is identical no matter which layer
+rejected the request. See the full exception-to-status-code mapping
+in the [README](../README.md#error-handling).
+
+---
+
+## Database Migrations
+
+Schema changes are exclusively version-controlled with Flyway
+(`src/main/resources/db/migration`):
+
+- `V1__initial_schema.sql` — core tables (`app_user`, `rol`,
+  `user_roles`, `reference` and its per-type subtype tables,
+  `refreshtoken`).
+- `V2__insert_roles.sql` — seeds the four application roles
+  (`ROLE_USER`, `ROLE_MANAGER`, `ROLE_ADMIN`, `ROLE_AUDITOR`).
+
+`spring.jpa.hibernate.ddl-auto` is set to `validate` in both `dev`
+and `prod`: Hibernate only checks that entity mappings match the
+Flyway-managed schema at startup — it never generates or applies DDL
+itself. This keeps all schema changes exclusively under Flyway's
+control and makes any drift between entities and the real schema fail
+fast at boot, instead of silently auto-patching the database. The
+`test` profile uses `create-drop` against an ephemeral database for
+test speed and isolation.
+
+---
+
+## Initial Data Seeding
+
+- Roles are inserted by the `V2__insert_roles.sql` Flyway migration.
+- The initial `admin` user is created at application startup by
+  `DataInitializer` (`infrastructure/config`), only if a user named
+  `admin` doesn't already exist. Its password comes from the required
+  `ADMIN_INITIAL_PASSWORD` environment variable — startup fails fast
+  if it's not set. `DataInitializer` does not run under the `test`
+  profile.
+
+---
+
+## Import / Export
+
+RIS and BibTeX import/export is delegated to the external `EILibrary`
+dependency via `ImportR` and `ExportR` (`component` package), which
+convert between `EILibrary`'s format-specific models and CodexRM's
+domain `Reference` model.
+
+- Accepted formats: `RIS`, `BIBTEX`.
+- Accepted file extensions on import: `.ris`, `.bib`, `.bibtex`.
+- Uploaded and exported temp files are given a UUID prefix and are
+  always deleted after the request completes (success or failure).
+- The export `fileName` parameter is sanitized server-side before
+  being used to build a file path, to prevent path traversal.
+
+See [Import / Export](../README.md#import--export) in the README for
+the client-facing contract (accepted formats, limits, error codes).
+
+---

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -309,3 +309,139 @@ Endpoints should include explicit documentation annotations such as:
 ```text
 docs/code-reading/springdoc-openapi.md
 ```
+
+---
+
+## ADR-009: Externalize All Secrets via Environment Variables
+
+### Status
+Accepted
+
+### Context
+
+During the security hardening phase (weeks 14-17), an audit found the
+JWT signing secret and the initial admin password hardcoded directly
+in `application-prod.properties` and `DataInitializer`, despite a
+comment claiming the secret came from an environment variable. Both
+values were already committed to git history, making them effectively
+compromised regardless of later code changes.
+
+### Decision
+
+All secrets (`JWT_SECRET`, `ADMIN_INITIAL_PASSWORD`,
+`CORS_ALLOWED_ORIGINS`) are read exclusively from environment
+variables, with no hardcoded fallback values. The application fails
+fast at startup if a required secret is missing (see `JwtUtils`'
+`@PostConstruct` validation and `DataInitializer`'s explicit null
+check). A secrets manager (e.g. Vault, AWS Secrets Manager) was
+considered but deferred — out of scope for the current deployment
+scale and infrastructure.
+
+### Consequences
+
+#### Positive
+- No secret value can be recovered from the source code or git
+  history going forward.
+- Fail-fast behavior surfaces missing configuration immediately at
+  startup instead of allowing insecure defaults to run silently.
+- Straightforward to rotate secrets without a code change.
+
+#### Negative
+- Slightly more setup friction for new environments (a `.env` file or
+  equivalent must be provisioned before the app can start).
+- No centralized secret rotation or audit trail — deferred to Fase 2
+  if the project's security requirements grow.
+
+---
+
+## ADR-010: Use `ddl-auto=validate` in Production Instead of `update`
+
+### Status
+Accepted
+
+### Context
+
+`application-prod.properties` had `spring.jpa.hibernate.ddl-auto=update`
+while `dev` correctly used `validate`. With `update`, Hibernate could
+silently alter the production schema on every startup based on entity
+mappings, bypassing Flyway's version-controlled migrations entirely
+and risking undocumented schema drift.
+
+### Decision
+
+Use `ddl-auto=validate` in both `dev` and `prod`. Hibernate only
+verifies that entity mappings match the schema Flyway already
+applied; it never generates or executes DDL itself. All schema
+changes go exclusively through versioned Flyway migration scripts.
+`test` keeps `create-drop` for speed and isolation against an
+ephemeral database.
+
+### Consequences
+
+#### Positive
+- Single source of truth for schema changes (Flyway), eliminating
+  drift between what migrations record and the real database state.
+- Any entity/schema mismatch fails the application at startup instead
+  of silently patching production.
+
+#### Negative
+- Every entity change now requires a corresponding Flyway migration
+  to be written by hand — no auto-generation shortcut during
+  development against `prod`-like validation.
+
+---
+
+## ADR-011: Standardize Error Responses Across All Failure Paths
+
+### Status
+Accepted
+
+### Context
+
+Error responses were inconsistent: some exceptions returned a shared
+`ErrorResponse` structure via `GlobalExceptionHandler`, but the JWT
+authentication entry point (401) built its own hand-written JSON with
+a different shape, and authorization denials at the security filter
+level (403) had no custom handler at all, falling back to Spring
+Security's default behavior. Some exceptions (`BadRequestException`,
+malformed JSON, oversized uploads, RIS/BibTeX parse errors) had no
+handler and fell through to a generic 500.
+
+### Decision
+
+All error paths — exceptions from controllers/services
+(`GlobalExceptionHandler`), unauthenticated requests
+(`AuthEntryPointJwt`), and authorization denials
+(`AccessDeniedHandlerImpl`) — return the same `ErrorResponse`
+structure (`timestamp`, `status`, `error`, `message`, `path`).
+Missing handlers were added for previously-uncaught exception types,
+each mapped to the correct HTTP status instead of a generic 500.
+
+### Consequences
+
+#### Positive
+- Any API consumer can rely on one consistent error shape regardless
+  of which layer rejected the request.
+- Correct HTTP status codes make client-side error handling
+  predictable (400 vs 401 vs 403 vs 413 vs 500).
+- The generic 500 handler no longer leaks raw exception messages to
+  clients; details are logged server-side only.
+
+#### Negative
+- Every new exception type introduced in the future must be
+  deliberately mapped to a handler, or it will silently fall back to
+  a generic 500 — this is a discipline requirement, not something
+  enforced automatically.
+
+---
+
+## Deferred: Exhaustive OpenAPI Audit
+
+An exhaustive audit of OpenAPI/Swagger annotation coverage and
+accuracy (beyond the basic `@Operation`/`@Schema` usage already in
+place, per ADR-008) was considered during the Fase 1 documentation
+week but not performed, as the critical suite, CI, and minimal
+hardening gates already consumed the available time this phase.
+
+This is logged here explicitly as **Fase 2 debt** — it does not block
+the closure of Fase 1.

--- a/docs/post-mortems/fase-1-jwt-secret-length.md
+++ b/docs/post-mortems/fase-1-jwt-secret-length.md
@@ -1,0 +1,83 @@
+# Post-Mortem: JWT Secret Length Failures Across Environments
+
+**Phase:** Fase 1, weeks 14-17 (security hardening)
+**Severity:** Medium (blocked local startup and integration tests
+multiple times; never reached production in a broken state)
+
+## Impact
+
+While externalizing the JWT secret from hardcoded values to
+environment variables (issue #136), the application failed to start
+on three separate occasions with:
+
+```
+IllegalArgumentException: JWT secret must be at least 64 characters
+long for HS512
+```
+
+This happened in three different contexts over the course of the
+same work session:
+
+1. Docker Desktop startup (`application-prod.properties`, secret
+   pulled from `.env`) — the value in `.env` was accidentally
+   truncated to 16 characters when copy-pasting from a generator's
+   output.
+2. `mvn verify` failing all 21 integration tests — the value manually
+   cleaned up in `application-integration.properties` (removing a
+   duplicated-property-name bug, a separate issue) ended up 63
+   characters instead of 64, one character short.
+3. An earlier Docker attempt where the `docker-compose.yml`-embedded
+   secret (before it was moved to `.env`) was also one character
+   short of 64.
+
+Each time, the fix required stopping, generating a new secret with
+a verified length, and restarting — a few minutes of lost time per
+occurrence, compounded across dev, test/integration, and prod-profile
+configuration files.
+
+## Root Cause
+
+Two compounding causes:
+
+1. **No tooling support for generating a correctly-sized secret.**
+   The secret was typed/copy-pasted manually across four different
+   properties files (`application-dev`, `application-test`,
+   `application-integration`, and the `.env` used by
+   `application-prod`), with no single source of truth and no
+   automated check before restart/test-run that the value actually
+   met the 64-character HS512 minimum.
+2. **The validation only fires at Spring context startup**
+   (`JwtUtils`'s `@PostConstruct` hook), which is correct for
+   fail-fast behavior, but means a bad secret is only discovered
+   after a full `mvn verify` run (up to ~1 minute) or a full Docker
+   rebuild, rather than immediately when the value is entered.
+
+## Fix
+
+- Each affected properties file was corrected with a verified
+  64-character value, checked explicitly before use with:
+```bash
+  echo -n "value" | wc -c
+```
+- The manual cleanup of a separate formatting bug (property name
+  duplicated inside its own value, e.g.
+  `codexrm.app.jwtSecret=codexrm.app.jwtSecret=...`) was redone
+  carefully to avoid accidentally shortening the actual secret value
+  again.
+
+## Prevention
+
+- `JwtUtils` already fails fast with a clear, specific error message
+  (`"JWT secret must be at least 64 characters long for HS512"`)
+  rather than allowing a weak secret to run silently — this is
+  working as intended and should be kept.
+- When generating or editing a JWT secret going forward, always
+  verify its length with `echo -n "$SECRET" | wc -c` (or
+  `openssl rand -hex 32`, which deterministically produces exactly
+  64 hex characters) **before** pasting it into any properties file,
+  rather than trusting a copy-paste to have preserved the full value.
+- Prefer generating the secret once and reusing the same verified
+  value across `dev`/`test`/`integration` (all non-sensitive,
+  non-production profiles) instead of retyping or re-copying it into
+  each file separately, which is where the truncation happened
+  repeatedly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,80 @@
+# Testing Notes
+
+This project has three layers of automated tests. This document
+explains what each one covers and when to run each one. For a deep
+dive into the critical integration suite specifically, see
+[integration-testing.md](integration-testing.md).
+
+## The Three Layers
+
+| Layer | What it covers | Database | Speed |
+|---|---|---|---|
+| **Unit tests** | Business logic in isolation (services, DTO converters, validators, exception handlers) — no Spring context, no database | none (mocked) | Fastest |
+| **Repository tests** | Spring Data JPA queries against real entity mappings | H2 (in-memory) | Fast |
+| **Integration tests** | Full application context: auth flows, authorization, sync, Flyway migrations, OpenAPI exposure | PostgreSQL via Testcontainers | Slower |
+
+Repository tests use H2 for speed, but H2 differs from PostgreSQL in
+SQL dialect, constraint enforcement, and transaction behavior — that
+gap is exactly why the critical integration suite exists and runs
+against real PostgreSQL instead. See
+[integration-testing.md](integration-testing.md) for details on what
+the critical suite protects.
+
+## What's Covered Where
+
+- **Unit**: `GlobalExceptionHandlerTest` (every exception → correct
+  status code and `ErrorResponse` shape), `UserServiceTest`,
+  `ReferenceServiceTest`, `RoleServiceTest`, `DTOConverterTest`,
+  `FieldValidationsTest`, `JwtUtilsTest`, and controller-level tests
+  like `ReferenceControllerTest` (includes import/export validation:
+  unsupported format, unsupported extension, path traversal
+  sanitization on export).
+- **Repository**: `UserRepositoryTest`, `ReferenceRepositoryTest`.
+- **Integration**: see [integration-testing.md](integration-testing.md)
+  — `AuthIntegrationTest`, `ReferenceFlowIntegrationTest`,
+  `ReferenceAuthorizationIntegrationTest`,
+  `ReferenceSynchronizationIntegrationTest`, `OpenApiIntegrationTest`,
+  plus Flyway migration validation on startup.
+
+## When to Run What
+
+- **While actively coding / fast local iteration:**
+```bash
+  mvn test
+```
+Runs unit + repository tests only (Surefire). Fast, no Docker
+required.
+
+- **Before opening a PR, or when the change touches auth, sync,
+  migrations, or API contracts:**
+```bash
+  mvn verify
+```
+Runs everything: unit + repository tests, then the full critical
+integration suite (Failsafe) against real PostgreSQL via
+Testcontainers. This is the gate that must pass before merging.
+Requires Docker running locally.
+
+- **To run a single integration test while debugging:**
+```bash
+  mvn -Dtest=ReferenceSynchronizationIntegrationTest test
+```
+
+## Requirements
+
+- Docker installed and running (required for `mvn verify` /
+  Testcontainers; not required for `mvn test`).
+- Internet access on first run, to pull the PostgreSQL Testcontainer
+  image.
+
+## Expected Result
+
+A clean run ends with:
+
+```text
+BUILD SUCCESS
+```
+
+Any `BUILD FAILURE` on `mvn verify` before a PR should be treated as
+blocking — this is the gate referenced in the Fase 1 success criteria
+("the pipeline stays green").


### PR DESCRIPTION
## Objective
Document only what helps run, test, and maintain the project. Prepare
a clean handoff toward Fase 2, without extensive documentation that
doesn't change the repo's day-to-day operability.

## Summary
Closes out week 18 (Fase 1 documentation). Verified and updated
existing docs against the real, current state of the project rather
than writing aspirational documentation.

## Changes

### README.md
- Verified "Run Locally" and "Run with Docker Compose" sections
  end-to-end (clone → docker → tests) — matched reality, no drift.
- Verified the Environment Variables table against the actual `.env`
  in use — confirmed complete and accurate.
- Added a "Local Validation" pre-PR checklist section.

### docs/architecture.md
- Already existed with solid coverage of layers, package structure,
  request lifecycle, and DTO/OpenAPI strategy.
- Added four sections covering work from weeks 14-17 that predated
  this doc: standardized error handling (`GlobalExceptionHandler`,
  `AuthEntryPointJwt`, `AccessDeniedHandlerImpl`), Flyway migrations
  and the `ddl-auto=validate` strategy, initial data seeding
  (`DataInitializer`), and RIS/BibTeX import/export.

### docs/decision-log.md
- Already existed with ADR-001 through ADR-008.
- Added ADR-009 (externalize all secrets via env vars, with fail-fast
  validation), ADR-010 (`ddl-auto=validate` in prod instead of
  `update`), and ADR-011 (standardize error responses across all
  failure paths).
- Logged the exhaustive OpenAPI audit as explicit Fase 2 debt — not
  performed this phase, doesn't block Fase 1 closure.

### docs/testing.md (new)
- Distinguishes unit, repository, and integration test layers, what
  each covers, and when to run `mvn test` vs `mvn verify`.
- Complements the existing `docs/integration-testing.md` (kept as-is,
  it already covers the critical suite in depth) rather than
  duplicating it.

### docs/post-mortems/fase-1-jwt-secret-length.md (new)
- Post-mortem for a real, repeated incident from this phase: JWT
  secret values shorter than the required 64 characters causing
  startup and integration test failures across dev, integration, and
  prod-profile configuration, three separate times during issue #136.
  Impact, root cause, fix, and prevention documented while the
  context was still fresh.

## Acceptance Criteria (week 18)
- [x] A new developer can boot the project without asking for extra context
- [x] Clear documentation exists for running the critical suite
- [x] Documentation reflects the current code, not the ideal roadmap
- [x] A short post-mortem exists (JWT secret length failures)

## Verification
No code changes in this PR — documentation only. `mvn verify` continues
to pass (no regressions from prior weeks).

closes #145
closes #146
closes #147
closes #148
closes #149